### PR TITLE
Expose getter and setter for trace metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "atla-insights"
-version = "0.0.1a13"
+version = "0.0.1a14"
 description = "Atla is a platform for monitoring and improving AI agents."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/atla_insights/__init__.py
+++ b/src/atla_insights/__init__.py
@@ -4,6 +4,7 @@ from logfire import instrument
 
 from ._main import (
     configure,
+    get_metadata,
     instrument_agno,
     instrument_anthropic,
     instrument_google_genai,
@@ -15,6 +16,7 @@ from ._main import (
     instrument_smolagents,
     mark_failure,
     mark_success,
+    set_metadata,
     uninstrument_agno,
     uninstrument_anthropic,
     uninstrument_google_genai,
@@ -28,6 +30,7 @@ from ._main import (
 
 __all__ = [
     "configure",
+    "get_metadata",
     "instrument",
     "instrument_agno",
     "instrument_anthropic",
@@ -40,6 +43,7 @@ __all__ = [
     "instrument_smolagents",
     "mark_failure",
     "mark_success",
+    "set_metadata",
     "uninstrument_agno",
     "uninstrument_anthropic",
     "uninstrument_google_genai",

--- a/uv.lock
+++ b/uv.lock
@@ -190,7 +190,7 @@ wheels = [
 
 [[package]]
 name = "atla-insights"
-version = "0.0.1a13"
+version = "0.0.1a14"
 source = { editable = "." }
 dependencies = [
     { name = "logfire" },


### PR DESCRIPTION
Expose a getter and setter method for trace-level metadata so users are able to retrieve & modify trace-level metadata throughout their application