### PR TITLE
Feature/contextvars

### DIFF
--- a/src/atla_insights/_main.py
+++ b/src/atla_insights/_main.py
@@ -122,6 +122,8 @@ class AtlaInsights:
 
         _metadata.set(metadata)
         if root_span := _root_span.get():
+            # If the root span already exists, we can assign the metadata to it.
+            # If not, it will be assigned the `_metadata` context var on creation.
             root_span.set_attribute(METADATA_MARK, json.dumps(metadata))
 
     def _instrument_provider(

--- a/src/atla_insights/_main.py
+++ b/src/atla_insights/_main.py
@@ -26,9 +26,9 @@ from ._constants import (
     SUPPORTED_LLM_PROVIDER,
 )
 from ._span_processors import (
+    AtlaRootSpanProcessor,
     _metadata,
     _root_span,
-    get_atla_root_span_processor,
     get_atla_span_processor,
 )
 from ._utils import validate_metadata
@@ -74,7 +74,7 @@ class AtlaInsights:
         additional_span_processors = additional_span_processors or []
         span_processors = [
             get_atla_span_processor(token),
-            get_atla_root_span_processor(),
+            AtlaRootSpanProcessor(),
             *additional_span_processors,
         ]
 

--- a/src/atla_insights/_span_processors.py
+++ b/src/atla_insights/_span_processors.py
@@ -41,11 +41,3 @@ def get_atla_span_processor(token: str) -> SpanProcessor:
         headers={"Authorization": f"Bearer {token}"},
     )
     return SimpleSpanProcessor(span_exporter)
-
-
-def get_atla_root_span_processor() -> AtlaRootSpanProcessor:
-    """Get an Atla root span processor.
-
-    :return (AtlaRootSpanProcessor): An Atla root span processor.
-    """
-    return AtlaRootSpanProcessor()

--- a/src/atla_insights/_span_processors.py
+++ b/src/atla_insights/_span_processors.py
@@ -6,7 +6,6 @@ from opentelemetry.context import Context
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
-from opentelemetry.util import types
 
 from ._constants import LOGFIRE_OTEL_TRACES_ENDPOINT, METADATA_MARK, SUCCESS_MARK
 
@@ -29,27 +28,6 @@ class AtlaRootSpanProcessor(SpanProcessor):
 
     def on_end(self, span: ReadableSpan) -> None:
         pass
-
-    def mark_root(self, value: types.AttributeValue) -> None:
-        """Mark the root span in the current trace with a value.
-
-        Args:
-            value: The value to mark the root span with.
-
-        Raises:
-            ValueError: If the root span is not found or is already marked.
-        """
-        root_span = _root_span.get()
-        if root_span is None:
-            raise ValueError(
-                "Atla marking can only be done within an instrumented function."
-            )
-        if root_span.attributes is None:
-            raise ValueError("Root span attributes are not set.")
-        if root_span.attributes.get(SUCCESS_MARK) != -1:
-            raise ValueError("Cannot mark the same instrumented function twice.")
-
-        root_span.set_attribute(SUCCESS_MARK, value)
 
 
 def get_atla_span_processor(token: str) -> SpanProcessor:

--- a/tests/test_span_processors.py
+++ b/tests/test_span_processors.py
@@ -3,8 +3,6 @@
 import json
 from typing import cast
 
-import pytest
-
 from tests._otel import BaseLocalOtel
 
 
@@ -187,19 +185,6 @@ class TestSpanProcessors(BaseLocalOtel):
 
         assert span.attributes is not None
         assert span.attributes.get(SUCCESS_MARK) == 1
-
-    def test_manual_marking_nok(self) -> None:
-        """Test that the instrumented function with a manual mark is traced."""
-        from src.atla_insights import instrument, mark_failure, mark_success
-
-        @instrument()
-        def test_function():
-            mark_success()
-            mark_failure()  # can only call once
-            return "test result"
-
-        with pytest.raises(ValueError):
-            test_function()
 
     def test_manual_marking_nested(self) -> None:
         """Test that the nested instrumented function with a manual mark is traced."""

--- a/tests/test_span_processors.py
+++ b/tests/test_span_processors.py
@@ -1,7 +1,10 @@
 """Test the span processors."""
 
+import asyncio
 import json
 from typing import cast
+
+import pytest
 
 from tests._otel import BaseLocalOtel
 
@@ -268,3 +271,74 @@ class TestSpanProcessors(BaseLocalOtel):
         assert span_1.attributes.get(SUCCESS_MARK) == 1
         assert span_2.attributes is not None
         assert span_2.attributes.get(SUCCESS_MARK) == -1
+
+    def test_metadata_fastapi_context_simulation(self) -> None:
+        """Test metadata functionality in a server context."""
+        from src.atla_insights import get_metadata, instrument, set_metadata
+
+        @instrument("mock_api_request")
+        def simulate_fastapi_request(user_id: str, session_id: str) -> bool:
+            """Simulate a API request handler."""
+            # Set request metadata
+            request_metadata = {
+                "user_id": user_id,
+                "session_id": session_id,
+                "endpoint": "test_api",
+            }
+            set_metadata(request_metadata)
+
+            # Verify metadata was set correctly
+            current = get_metadata()
+            assert current == request_metadata
+
+            # Update metadata during processing
+            updated = request_metadata.copy()
+            updated["status"] = "processed"
+            set_metadata(updated)
+
+            # Verify final metadata
+            final = get_metadata()
+            return final == updated
+
+        # Test multiple "requests" in sequence
+        assert simulate_fastapi_request("user1", "session1")
+        assert simulate_fastapi_request("user2", "session2")
+
+    @pytest.mark.asyncio
+    async def test_metadata_fastapi_context_simulation_async(self) -> None:
+        """Test metadata functionality in async server context."""
+        from src.atla_insights import get_metadata, instrument, set_metadata
+
+        @instrument("mock_async_api_request")
+        async def simulate_async_fastapi_request(user_id: str, session_id: str) -> bool:
+            """Simulate an async API request handler."""
+            # Set request metadata
+            request_metadata = {
+                "user_id": user_id,
+                "session_id": session_id,
+                "endpoint": "test_async_api",
+            }
+            set_metadata(request_metadata)
+
+            # Simulate some async operation
+            await asyncio.sleep(0.01)
+
+            # Verify metadata was preserved across await
+            current = get_metadata()
+            assert current == request_metadata
+
+            # Update metadata during processing
+            updated = request_metadata.copy()
+            updated["status"] = "processed"
+            set_metadata(updated)
+
+            # Another async operation
+            await asyncio.sleep(0.01)
+
+            # Verify final metadata after async operations
+            final = get_metadata()
+            return final == updated
+
+        # Test multiple async "requests"
+        assert await simulate_async_fastapi_request("user1", "session1")
+        assert await simulate_async_fastapi_request("user2", "session2")


### PR DESCRIPTION
Make `metadata` & `root_span` variables `ContextVar`s so that we ensure proper context separation in case of e.g. a FastAPI setup