### PR TITLE
Feature/tool invocations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "opentelemetry-api>=1.32.1",
     "opentelemetry-exporter-otlp-proto-grpc>=1.32.1",
     "pydantic>=2.11.4",
+    "wrapt>=1.17.2",
 ]
 
 [dependency-groups]

--- a/src/atla_insights/_crewai.py
+++ b/src/atla_insights/_crewai.py
@@ -58,7 +58,10 @@ class _ToolUseWrapper:
     ) -> Any:
         if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
             return wrapped(*args, **kwargs)
-        if instance:
+        if kwargs.get("tool") or len(args) > 1:
+            tool = kwargs.get("tool") or args[1]
+            span_name = tool.name
+        elif instance:
             span_name = f"{instance.__class__.__name__}.{wrapped.__name__}"
         else:
             span_name = wrapped.__name__

--- a/src/atla_insights/_crewai.py
+++ b/src/atla_insights/_crewai.py
@@ -4,6 +4,8 @@ import os
 from importlib import import_module
 from typing import Any, Callable, Mapping, Tuple
 
+from opentelemetry import context as context_api
+from opentelemetry import trace as trace_api
 from opentelemetry.trace import Tracer
 from wrapt import wrap_function_wrapper
 
@@ -11,12 +13,19 @@ try:
     import litellm
     from crewai.telemetry.telemetry import Telemetry
     from crewai.utilities.events.event_listener import event_listener
+    from openinference.instrumentation import (
+        get_attributes_from_context,
+        get_output_attributes,
+        safe_json_dumps,
+    )
     from openinference.instrumentation.crewai import CrewAIInstrumentor
     from openinference.instrumentation.crewai._wrappers import (
         _ExecuteCoreWrapper,
+        _flatten,
+        _get_input_value,
         _KickoffWrapper,
-        _ToolUseWrapper,
     )
+    from openinference.semconv.trace import OpenInferenceSpanKindValues, SpanAttributes
 except ImportError as e:
     raise ImportError(
         "CrewAI instrumentation needs to be installed. "
@@ -34,6 +43,68 @@ def _set_callbacks(
         for callback in callbacks:
             if callback not in litellm.callbacks:
                 litellm.callbacks.append(callback)
+
+
+class _ToolUseWrapper:
+    def __init__(self, tracer: trace_api.Tracer) -> None:
+        self._tracer = tracer
+
+    def __call__(
+        self,
+        wrapped: Callable[..., Any],
+        instance: Any,
+        args: Tuple[Any, Any, Any],
+        kwargs: Mapping[str, Any],
+    ) -> Any:
+        if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
+            return wrapped(*args, **kwargs)
+        if instance:
+            span_name = f"{instance.__class__.__name__}.{wrapped.__name__}"
+        else:
+            span_name = wrapped.__name__
+        with self._tracer.start_as_current_span(
+            span_name,
+            attributes=dict(
+                _flatten(
+                    {
+                        SpanAttributes.OPENINFERENCE_SPAN_KIND: OpenInferenceSpanKindValues.TOOL,  # noqa: E501
+                        SpanAttributes.INPUT_VALUE: _get_input_value(
+                            wrapped,
+                            *args,
+                            **kwargs,
+                        ),
+                    }
+                )
+            ),
+            record_exception=False,
+            set_status_on_exception=False,
+        ) as span:
+            if kwargs.get("tool") or len(args) > 1:
+                tool = kwargs.get("tool") or args[1]
+
+                span.set_attribute(SpanAttributes.TOOL_NAME, tool.name)
+                span.set_attribute(SpanAttributes.TOOL_DESCRIPTION, tool.description)
+
+            if kwargs.get("tool_calling") or len(args) > 2:
+                tool_calling = kwargs.get("tool_calling") or args[2]
+                span.set_attribute(
+                    SpanAttributes.TOOL_PARAMETERS,
+                    safe_json_dumps(tool_calling.arguments),
+                )
+
+            span.set_attribute("function_calling_llm", instance.function_calling_llm)
+            try:
+                response = wrapped(*args, **kwargs)
+            except Exception as exception:
+                span.set_status(
+                    trace_api.Status(trace_api.StatusCode.ERROR, str(exception))
+                )
+                span.record_exception(exception)
+                raise
+            span.set_status(trace_api.StatusCode.OK)
+            span.set_attributes(dict(get_output_attributes(response)))
+            span.set_attributes(dict(get_attributes_from_context()))
+        return response
 
 
 class AtlaCrewAIInstrumentor(CrewAIInstrumentor):

--- a/src/atla_insights/_crewai.py
+++ b/src/atla_insights/_crewai.py
@@ -2,7 +2,7 @@
 
 import os
 from importlib import import_module
-from typing import Any, Callable, Mapping, Tuple
+from typing import Any, Callable, Mapping
 
 from opentelemetry import context as context_api
 from opentelemetry import trace as trace_api
@@ -36,7 +36,7 @@ except ImportError as e:
 def _set_callbacks(
     wrapped: Callable[..., Any],
     instance: Any,
-    args: Tuple[Any, ...],
+    args: tuple[Any, ...],
     kwargs: Mapping[str, Any],
 ) -> None:
     if callbacks := kwargs.get("callbacks"):
@@ -53,7 +53,7 @@ class _ToolUseWrapper:
         self,
         wrapped: Callable[..., Any],
         instance: Any,
-        args: Tuple[Any, Any, Any],
+        args: tuple[Any, Any, Any],
         kwargs: Mapping[str, Any],
     ) -> Any:
         if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):

--- a/src/atla_insights/_langchain.py
+++ b/src/atla_insights/_langchain.py
@@ -3,10 +3,17 @@
 import ast
 from typing import Any
 
-from openinference.instrumentation import safe_json_dumps
-from openinference.instrumentation.langchain import LangChainInstrumentor
-from openinference.semconv.trace import SpanAttributes
 from wrapt import wrap_function_wrapper
+
+try:
+    from openinference.instrumentation import safe_json_dumps
+    from openinference.instrumentation.langchain import LangChainInstrumentor
+    from openinference.semconv.trace import SpanAttributes
+except ImportError as e:
+    raise ImportError(
+        "LangChain instrumentation needs to be installed. "
+        "Please install it via `pip install atla-insights[langchain]`."
+    ) from e
 
 
 def _tools(wrapped: Any, instance: Any, args: Any, kwargs: Any) -> Any:

--- a/src/atla_insights/_langchain.py
+++ b/src/atla_insights/_langchain.py
@@ -1,0 +1,35 @@
+"""LangChain instrumentation."""
+
+import ast
+from typing import Any
+
+from openinference.instrumentation import safe_json_dumps
+from openinference.instrumentation.langchain import LangChainInstrumentor
+from openinference.semconv.trace import SpanAttributes
+from wrapt import wrap_function_wrapper
+
+
+def _tools(wrapped: Any, instance: Any, args: Any, kwargs: Any) -> Any:
+    """Wrap the tools function to include tool parameters information."""
+    yield from wrapped(*args, **kwargs)
+
+    run = args[0]
+    if parameters := run.inputs.get("input"):
+        try:
+            parameters = ast.literal_eval(parameters)
+        except Exception:
+            pass
+        finally:
+            yield SpanAttributes.TOOL_PARAMETERS, safe_json_dumps(parameters)
+
+
+class AtlaLangChainInstrumentor(LangChainInstrumentor):
+    """Atla instrumentor for LangChain."""
+
+    def _instrument(self, **kwargs: Any) -> None:
+        wrap_function_wrapper(
+            "openinference.instrumentation.langchain._tracer",
+            "_tools",
+            _tools,
+        )
+        super()._instrument(**kwargs)

--- a/src/atla_insights/_langchain.py
+++ b/src/atla_insights/_langchain.py
@@ -34,9 +34,12 @@ class AtlaLangChainInstrumentor(LangChainInstrumentor):
     """Atla instrumentor for LangChain."""
 
     def _instrument(self, **kwargs: Any) -> None:
+        # Wrap original _tools functionality that includes tool parameters information.
         wrap_function_wrapper(
             "openinference.instrumentation.langchain._tracer",
             "_tools",
             _tools,
         )
+
+        # Run original instrumentation which uses the wrapped _tools function.
         super()._instrument(**kwargs)

--- a/src/atla_insights/_main.py
+++ b/src/atla_insights/_main.py
@@ -226,13 +226,7 @@ class AtlaInsights:
 
     def instrument_langchain(self) -> ContextManager[None]:
         """Instrument the Langchain framework."""
-        try:
-            from ._langchain import AtlaLangChainInstrumentor
-        except ImportError as e:
-            raise ImportError(
-                "Langchain instrumentation needs to be installed. "
-                "Please install it via `pip install atla-insights[langchain]`."
-            ) from e
+        from ._langchain import AtlaLangChainInstrumentor
 
         return self._instrument_provider(
             provider="langchain",
@@ -383,19 +377,13 @@ class AtlaInsights:
         :param llm_provider (Union[Sequence[SUPPORTED_LLM_PROVIDER],
             SUPPORTED_LLM_PROVIDER]): The LLM provider(s) to instrument.
         """
-        try:
-            from openinference.instrumentation.smolagents import SmolagentsInstrumentor
-        except ImportError as e:
-            raise ImportError(
-                "Smolagents instrumentation needs to be installed. "
-                "Please install it via `pip install atla-insights[smolagents]`."
-            ) from e
+        from ._smolagents import AtlaSmolAgentsInstrumentor
 
         return self._instrument_provider(
             provider="smolagents",
             instrumentors=[
                 *self._get_instrumentors_for_provider(llm_provider),
-                SmolagentsInstrumentor(),
+                AtlaSmolAgentsInstrumentor(),
             ],
         )
 

--- a/src/atla_insights/_main.py
+++ b/src/atla_insights/_main.py
@@ -227,7 +227,7 @@ class AtlaInsights:
     def instrument_langchain(self) -> ContextManager[None]:
         """Instrument the Langchain framework."""
         try:
-            from openinference.instrumentation.langchain import LangChainInstrumentor
+            from ._langchain import AtlaLangChainInstrumentor
         except ImportError as e:
             raise ImportError(
                 "Langchain instrumentation needs to be installed. "
@@ -236,7 +236,7 @@ class AtlaInsights:
 
         return self._instrument_provider(
             provider="langchain",
-            instrumentors=[LangChainInstrumentor()],
+            instrumentors=[AtlaLangChainInstrumentor()],
         )
 
     def uninstrument_langchain(self) -> None:

--- a/src/atla_insights/_openai_agents.py
+++ b/src/atla_insights/_openai_agents.py
@@ -2,9 +2,12 @@
 
 from typing import Any
 
+from wrapt import wrap_function_wrapper
+
 try:
     from agents import set_trace_processors
     from openinference.instrumentation.openai_agents import OpenAIAgentsInstrumentor
+    from openinference.semconv.trace import SpanAttributes
 except ImportError as e:
     raise ImportError(
         "OpenAI agents instrumentation needs to be installed. "
@@ -12,8 +15,32 @@ except ImportError as e:
     ) from e
 
 
+def _get_attributes_from_function_span_data(
+    wrapped: Any, instance: Any, args: Any, kwargs: Any
+) -> Any:
+    """Wrap the _get_attributes_from_function_span_data function to add tool params."""
+    yield from wrapped(*args, **kwargs)
+
+    obj = args[0]
+    if obj.input:
+        yield SpanAttributes.TOOL_PARAMETERS, obj.input
+    else:
+        yield SpanAttributes.TOOL_PARAMETERS, "{}"
+
+    if obj.output is None:
+        yield SpanAttributes.OUTPUT_VALUE, "{}"
+
+
 class AtlaOpenAIAgentsInstrumentor(OpenAIAgentsInstrumentor):
     """Atla OpenAI Agents SDK instrumentor class."""
+
+    def _instrument(self, **kwargs: Any) -> None:
+        wrap_function_wrapper(
+            "openinference.instrumentation.openai_agents._processor",
+            "_get_attributes_from_function_span_data",
+            _get_attributes_from_function_span_data,
+        )
+        super()._instrument(**kwargs)
 
     def _uninstrument(self, **kwargs: Any) -> None:
         set_trace_processors([])

--- a/src/atla_insights/_smolagents.py
+++ b/src/atla_insights/_smolagents.py
@@ -99,7 +99,7 @@ class AtlaSmolAgentsInstrumentor(SmolagentsInstrumentor):
         super()._instrument(**kwargs)
 
         if self._original_tool_call_method is not None:
-            Tool.__call__ = self._original_tool_call_method
+            Tool.__call__ = self._original_tool_call_method  # type: ignore[method-assign]
 
         wrap_function_wrapper(
             module="smolagents",

--- a/src/atla_insights/_smolagents.py
+++ b/src/atla_insights/_smolagents.py
@@ -1,0 +1,108 @@
+"""SmolAgents instrumentation."""
+
+from typing import Any, Callable, Iterator, Mapping, Tuple
+
+from opentelemetry import context as context_api
+from opentelemetry import trace as trace_api
+from wrapt import wrap_function_wrapper
+
+try:
+    from openinference.instrumentation import safe_json_dumps
+    from openinference.instrumentation.context_attributes import (
+        get_attributes_from_context,
+    )
+    from openinference.instrumentation.smolagents import SmolagentsInstrumentor
+    from openinference.instrumentation.smolagents._wrappers import (
+        _bind_arguments,
+        _get_input_value,
+        _output_value_and_mime_type_for_tool_span,
+        _strip_method_args,
+    )
+    from openinference.semconv.trace import OpenInferenceSpanKindValues, SpanAttributes
+    from smolagents import Tool
+except ImportError as e:
+    raise ImportError(
+        "SmolAgents instrumentation needs to be installed. "
+        "Please install it via `pip install atla-insights[smolagents]`."
+    ) from e
+
+
+def _tools(tool: "Tool") -> Iterator[Tuple[str, Any]]:
+    if tool_name := getattr(tool, "name", None):
+        yield SpanAttributes.TOOL_NAME, tool_name
+    if tool_description := getattr(tool, "description", None):
+        yield SpanAttributes.TOOL_DESCRIPTION, tool_description
+
+
+def _tool_parameters(
+    wrapped: Callable[..., Any],
+    *args: Any,
+    **kwargs: Any,
+) -> Iterator[Tuple[str, Any]]:
+    """Get the tool parameters from the wrapped function."""
+    arguments = _bind_arguments(wrapped, *args, **kwargs)
+    arguments = _strip_method_args(arguments)
+
+    tool_parameters = {**arguments.get("kwargs", {})}
+    if tool_args := arguments.get("args"):
+        tool_parameters["args"] = tool_args
+
+    yield SpanAttributes.TOOL_PARAMETERS, safe_json_dumps(tool_parameters)
+
+
+class _ToolCallWrapper:
+    def __init__(self, tracer: trace_api.Tracer) -> None:
+        self._tracer = tracer
+
+    def __call__(
+        self,
+        wrapped: Callable[..., Any],
+        instance: Any,
+        args: Tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> Any:
+        if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
+            return wrapped(*args, **kwargs)
+
+        if hasattr(instance, "name"):
+            span_name = instance.name
+        else:
+            span_name = f"{instance.__class__.__name__}"
+
+        with self._tracer.start_as_current_span(
+            span_name,
+            attributes={
+                SpanAttributes.OPENINFERENCE_SPAN_KIND: OpenInferenceSpanKindValues.TOOL.value,  # noqa: E501
+                SpanAttributes.INPUT_VALUE: _get_input_value(wrapped, *args, **kwargs),
+                **dict(_tools(instance)),
+                **dict(_tool_parameters(wrapped, *args, **kwargs)),
+                **dict(get_attributes_from_context()),
+            },
+        ) as span:
+            response = wrapped(*args, **kwargs)
+            span.set_status(trace_api.StatusCode.OK)
+            span.set_attributes(
+                dict(
+                    _output_value_and_mime_type_for_tool_span(
+                        response=response,
+                        output_type=instance.output_type,
+                    )
+                )
+            )
+        return response
+
+
+class AtlaSmolAgentsInstrumentor(SmolagentsInstrumentor):
+    """Atla SmolAgents SDK instrumentor class."""
+
+    def _instrument(self, **kwargs: Any) -> None:
+        super()._instrument(**kwargs)
+
+        if self._original_tool_call_method is not None:
+            Tool.__call__ = self._original_tool_call_method
+
+        wrap_function_wrapper(
+            module="smolagents",
+            name="Tool.__call__",
+            wrapper=_ToolCallWrapper(self._tracer),
+        )

--- a/tests/instrumentation/test_agno.py
+++ b/tests/instrumentation/test_agno.py
@@ -237,7 +237,7 @@ class TestAgnoInstrumentation(BaseLocalOtel):
         with instrument_agno("openai"):
             fn = Function(
                 name="test_function",
-                description="Test function",
+                description="Test function.",
                 parameters={
                     "type": "object",
                     "properties": {"some-arg": {"type": "string"}},
@@ -263,7 +263,7 @@ class TestAgnoInstrumentation(BaseLocalOtel):
         assert span.attributes.get("openinference.span.kind") == "TOOL"
 
         assert span.attributes.get("tool.name") == "test_function"
-        assert span.attributes.get("tool.description") == "Test function"
+        assert span.attributes.get("tool.description") == "Test function."
         assert span.attributes.get("tool.parameters") == '{"some-arg": "some-value"}'
 
         assert span.attributes.get("input.value") == '{"some-arg": "some-value"}'

--- a/tests/instrumentation/test_agno.py
+++ b/tests/instrumentation/test_agno.py
@@ -259,8 +259,12 @@ class TestAgnoInstrumentation(BaseLocalOtel):
         assert span.name == "test_function"
 
         assert span.attributes is not None
+
         assert span.attributes.get("openinference.span.kind") == "TOOL"
+
         assert span.attributes.get("tool.name") == "test_function"
         assert span.attributes.get("tool.description") == "Test function"
         assert span.attributes.get("tool.parameters") == '{"some-arg": "some-value"}'
+
+        assert span.attributes.get("input.value") == '{"some-arg": "some-value"}'
         assert span.attributes.get("output.value") == "some-result"

--- a/tests/instrumentation/test_agno.py
+++ b/tests/instrumentation/test_agno.py
@@ -245,7 +245,7 @@ class TestAgnoInstrumentation(BaseLocalOtel):
             )
             function_call = FunctionCall(
                 function=fn,
-                arguments={"some-arg": "some-value"},
+                arguments={"some_arg": "some-value"},
                 result="some-result",
                 call_id="abc123",
             )
@@ -264,7 +264,7 @@ class TestAgnoInstrumentation(BaseLocalOtel):
 
         assert span.attributes.get("tool.name") == "test_function"
         assert span.attributes.get("tool.description") == "Test function."
-        assert span.attributes.get("tool.parameters") == '{"some-arg": "some-value"}'
+        assert span.attributes.get("tool.parameters") == '{"some_arg": "some-value"}'
 
-        assert span.attributes.get("input.value") == '{"some-arg": "some-value"}'
+        assert span.attributes.get("input.value") == '{"some_arg": "some-value"}'
         assert span.attributes.get("output.value") == "some-result"

--- a/tests/instrumentation/test_crewai.py
+++ b/tests/instrumentation/test_crewai.py
@@ -119,7 +119,7 @@ class TestCrewAIInstrumentation(BaseLocalOtel):
         assert request.name == "litellm_request"
 
     def test_tool_invocation(self) -> None:
-        """Test the Agno instrumentation with tool invocation."""
+        """Test the CrewAI instrumentation with tool invocation."""
         from src.atla_insights import instrument_crewai
 
         with instrument_crewai():
@@ -146,11 +146,14 @@ class TestCrewAIInstrumentation(BaseLocalOtel):
 
         [span] = finished_spans
 
-        assert span.name == "ToolUsage._use"
+        assert span.name == "test_function"
 
         assert span.attributes is not None
         assert span.attributes.get("openinference.span.kind") == "TOOL"
+
         assert span.attributes.get("tool.name") == "test_function"
         assert span.attributes.get("tool.description") == "Test function."
         assert span.attributes.get("tool.parameters") == '{"some_arg": "some-value"}'
+
+        assert span.attributes.get("input.value") is not None
         assert span.attributes.get("output.value") == "some-result"

--- a/tests/instrumentation/test_crewai.py
+++ b/tests/instrumentation/test_crewai.py
@@ -2,6 +2,7 @@
 
 import pytest
 from crewai import LLM, Agent, Crew, Task
+from crewai.tools.tool_usage import CrewStructuredTool, ToolCalling, ToolUsage
 from openai import OpenAI
 
 from tests._otel import BaseLocalOtel
@@ -116,3 +117,40 @@ class TestCrewAIInstrumentation(BaseLocalOtel):
         assert kickoff.name == "Crew.kickoff"
         assert execute.name == "Task._execute_core"
         assert request.name == "litellm_request"
+
+    def test_tool_invocation(self) -> None:
+        """Test the Agno instrumentation with tool invocation."""
+        from src.atla_insights import instrument_crewai
+
+        with instrument_crewai():
+
+            def test_function(some_arg: str) -> str:
+                """Test function."""
+                return "some-result"
+
+            tool = CrewStructuredTool.from_function(func=test_function)
+            tool_usage = ToolUsage(
+                tools_handler=None,
+                tools=[tool],
+                task=None,
+                function_calling_llm=None,
+            )
+            tool_calling = ToolCalling(
+                tool_name="test_function",
+                arguments={"some_arg": "some-value"},
+            )
+            tool_usage._use("test_function", tool, tool_calling)
+
+        finished_spans = self.get_finished_spans()
+        assert len(finished_spans) == 1
+
+        [span] = finished_spans
+
+        assert span.name == "ToolUsage._use"
+
+        assert span.attributes is not None
+        assert span.attributes.get("openinference.span.kind") == "TOOL"
+        assert span.attributes.get("tool.name") == "test_function"
+        assert span.attributes.get("tool.description") == "Test function."
+        assert span.attributes.get("tool.parameters") == '{"some_arg": "some-value"}'
+        assert span.attributes.get("output.value") == "some-result"

--- a/tests/instrumentation/test_openai_agents.py
+++ b/tests/instrumentation/test_openai_agents.py
@@ -3,7 +3,16 @@
 from typing import Any, cast
 
 import pytest
-from agents import Agent, OpenAIChatCompletionsModel, Runner, set_default_openai_client
+from agents import (
+    Agent,
+    OpenAIChatCompletionsModel,
+    RunConfig,
+    RunHooks,
+    Runner,
+    set_default_openai_client,
+)
+from agents._run_impl import RunImpl, ToolRunFunction, TraceCtxManager
+from agents.run_context import RunContextWrapper
 from agents.tool import function_tool
 from openai import AsyncOpenAI
 from openai.types.responses import ResponseFunctionToolCall
@@ -98,10 +107,6 @@ class TestOpenaiAgentsInstrumentation(BaseLocalOtel):
     @pytest.mark.asyncio
     async def test_tool_invocation(self, mock_async_openai_client: AsyncOpenAI) -> None:
         """Test the OpenAI Agents SDK instrumentation with tool invocation."""
-        from agents import RunConfig, RunHooks
-        from agents._run_impl import RunImpl, ToolRunFunction, TraceCtxManager
-        from agents.run_context import RunContextWrapper
-
         from src.atla_insights import instrument_openai_agents
 
         with instrument_openai_agents():

--- a/tests/instrumentation/test_openai_agents.py
+++ b/tests/instrumentation/test_openai_agents.py
@@ -1,8 +1,12 @@
 """Unit tests for the OpenAI Agents instrumentation."""
 
+from typing import Any, cast
+
 import pytest
 from agents import Agent, OpenAIChatCompletionsModel, Runner, set_default_openai_client
+from agents.tool import function_tool
 from openai import AsyncOpenAI
+from openai.types.responses import ResponseFunctionToolCall
 
 from tests._otel import BaseLocalOtel
 
@@ -90,3 +94,69 @@ class TestOpenaiAgentsInstrumentation(BaseLocalOtel):
             request.attributes.get("llm.output_messages.0.message.content")
             == "hello world"
         )
+
+    @pytest.mark.asyncio
+    async def test_tool_invocation(self, mock_async_openai_client: AsyncOpenAI) -> None:
+        """Test the OpenAI Agents SDK instrumentation with tool invocation."""
+        from agents import RunConfig, RunHooks
+        from agents._run_impl import RunImpl, ToolRunFunction, TraceCtxManager
+        from agents.run_context import RunContextWrapper
+
+        from src.atla_insights import instrument_openai_agents
+
+        with instrument_openai_agents():
+            with TraceCtxManager(
+                workflow_name="unit-test",
+                trace_id="abc-123",
+                group_id="abc-123",
+                metadata={"some": "metadata"},
+                disabled=False,
+            ):
+
+                @function_tool
+                def test_function(some_arg: str) -> str:
+                    """Test function."""
+                    return "some-result"
+
+                await RunImpl.execute_function_tool_calls(
+                    agent=Agent(
+                        name="Hello world",
+                        instructions="You are a helpful agent.",
+                        model=OpenAIChatCompletionsModel(
+                            model="some-model",
+                            openai_client=mock_async_openai_client,
+                        ),
+                    ),
+                    tool_runs=[
+                        ToolRunFunction(
+                            tool_call=ResponseFunctionToolCall(
+                                arguments='{"some_arg": "some-value"}',
+                                call_id="abc123",
+                                type="function_call",
+                                name="test_function",
+                            ),
+                            function_tool=test_function,
+                        ),
+                    ],
+                    hooks=RunHooks(),
+                    context_wrapper=cast(RunContextWrapper[Any], RunContextWrapper({})),
+                    config=RunConfig(),
+                )
+
+        finished_spans = self.get_finished_spans()
+        assert len(finished_spans) == 2
+
+        root_span, tool_span = finished_spans
+
+        assert root_span.name == "unit-test"
+        assert tool_span.name == "test_function"
+
+        assert tool_span.attributes is not None
+        assert tool_span.attributes.get("openinference.span.kind") == "TOOL"
+
+        assert tool_span.attributes.get("tool.name") == "test_function"
+        # TODO: Add test for tool description once supported.
+        assert tool_span.attributes.get("tool.parameters") == '{"some_arg": "some-value"}'
+
+        assert tool_span.attributes.get("input.value") == '{"some_arg": "some-value"}'
+        assert tool_span.attributes.get("output.value") == "some-result"

--- a/uv.lock
+++ b/uv.lock
@@ -217,6 +217,7 @@ dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
     { name = "pydantic" },
+    { name = "wrapt" },
 ]
 
 [package.optional-dependencies]
@@ -305,6 +306,7 @@ requires-dist = [
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.32.1" },
     { name = "pydantic", specifier = ">=2.11.4" },
     { name = "ruff", marker = "extra == 'ci'", specifier = ">=0.11.7" },
+    { name = "wrapt", specifier = ">=1.17.2" },
 ]
 provides-extras = ["agno", "anthropic", "ci", "crewai", "google-genai", "langchain", "litellm", "mcp", "openai", "openai-agents", "smolagents"]
 


### PR DESCRIPTION
Ensure tool invocations get logged in a consistent, framework-agnostic way.
Specifically, we ensure:
- The tool invocation span name is the name of the function.
- The `openinference.span.kind` attribute equals `TOOL`.
- The `tool.name` attribute is the name of the function.
- The `tool.description` attribute gets the tool description, if exists.
- The `tool.parameters` attribute gets the invocation parameters.
- The `input.value` gets an arbitrary, non-null dump of the inputs
- The `output.value` gets the tool output(s), if exists.