### PR TITLE
Ensure compatibility with other otel services

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,16 +250,20 @@ client = OpenAI()
 client.chat.completions.create(...)
 ```
 
-#### Logfire compatibility
-
-The `atla_insights` package's instrumentation is powered by [Pydantic Logfire](logfire.pydantic.dev/docs/).
-> ⚠️ This means that we do not (currently) support compatibility with existing LogFire
-instrumentation / observability.
-
 #### OpenTelemetry compatibility
 
-Next to the above, you also have the ability to export traces to any arbitrary additional
-opentelemetry provider by following this example:
+The Alta Insights SDK is built on the OpenTelemetry standard and fully compatible with
+other OpenTelemetry services.
+
+If you have an existing OpenTelemetry setup (e.g. by setting the relevant otel
+environment variables), Atla Insights will be _additive_ to this setup. I.e. it will add
+additional logging on top of what is already getting logged.
+
+If you do not have an existing OpenTelemetry setup, Atla Insights will initialize a new
+(global) tracer provider.
+
+Next to the above, you also have the ability to add any arbitrary additional span
+processors by following the example below:
 
 ```python
 from atla_insights import configure

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ We currently support the following LLM providers:
 | Framework / Provider          | Instrumentation Function   | Notes |
 |-------------------------------|----------------------------|-------|
 | **Anthropic**                 | `instrument_anthropic`     | |
-| **Google GenAI**              | `instrument_google_genai`  | E.g. Gemini |
+| **Google GenAI**              | `instrument_google_genai`  | E.g., Gemini |
 | **LiteLLM**                   | `instrument_litellm`       | Supports all available models in the LiteLLM framework |
 | **OpenAI**                    | `instrument_openai`        | |
 
@@ -123,7 +123,7 @@ We currently support the following frameworks:
 |-------------------------------|----------------------------|-------|
 | **Agno**                      | `instrument_agno`          | Supported with `openai`, `google-genai`, `litellm` and/or `anthropic` models* |
 | **CrewAI**                    | `instrument_crewai`        | |
-| **LangChain**                 | `instrument_langchain`     | This includes e.g. LangGraph as well |
+| **LangChain**                 | `instrument_langchain`     | This includes e.g., LangGraph as well |
 | **MCP**                       | `instrument_mcp`           | Only includes context propagation. You will need to instrument the model calling the MCP server separately. |
 | **OpenAI Agents**             | `instrument_openai_agents` | Supported with `openai`, `google-genai`, `litellm` and/or `anthropic` models* |
 | **Smolagents**                | `instrument_smolagents`    | Supported with `openai`, `google-genai`, `litellm` and/or `anthropic` models* |
@@ -136,10 +136,10 @@ from atla_insights import configure, instrument, instrument_agno
 
 configure(...)
 
-# If you are using a single LLM provider (e.g. via `OpenAIChat`).
+# If you are using a single LLM provider (e.g., via `OpenAIChat`).
 instrument_agno("openai")
 
-# If you are using multiple LLM providers (e.g. `OpenAIChat` and `Claude`).
+# If you are using multiple LLM providers (e.g., `OpenAIChat` and `Claude`).
 instrument_agno(["anthropic", "openai"])
 ```
 
@@ -236,7 +236,7 @@ with our instrumentation / observability providers.
 `atla_insights` instrumentation is generally compatible with most popular observability
 platforms.
 
-E.g. the following code snippet will make tracing available in both Atla and Langfuse.
+E.g., the following code snippet will make tracing available in both Atla and Langfuse.
 
 ```python
 from atla_insights import configure, instrument_openai
@@ -252,11 +252,11 @@ client.chat.completions.create(...)
 
 #### OpenTelemetry compatibility
 
-The Alta Insights SDK is built on the OpenTelemetry standard and fully compatible with
+The Atla Insights SDK is built on the OpenTelemetry standard and fully compatible with
 other OpenTelemetry services.
 
-If you have an existing OpenTelemetry setup (e.g. by setting the relevant otel
-environment variables), Atla Insights will be _additive_ to this setup. I.e. it will add
+If you have an existing OpenTelemetry setup (e.g., by setting the relevant otel
+environment variables), Atla Insights will be _additive_ to this setup. I.e., it will add
 additional logging on top of what is already getting logged.
 
 If you do not have an existing OpenTelemetry setup, Atla Insights will initialize a new

--- a/examples/marking.py
+++ b/examples/marking.py
@@ -43,7 +43,7 @@ def main() -> None:
     client = OpenAI()
 
     # Instrument the OpenAI client
-    instrument_openai(client)
+    instrument_openai()
 
     # Calling the instrumented OpenAI client will create spans behind the scenes
     my_app(client)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ classifiers = [
     "Programming Language :: Python :: 3.10"
 ]
 dependencies = [
-    "logfire>=3.14.1",
     "openai>=1.77.0",
     "openinference-instrumentation>=0.1.32",
     "openinference-semantic-conventions>=0.1.17",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "opentelemetry-api>=1.32.1",
     "opentelemetry-exporter-otlp-proto-grpc>=1.32.1",
     "pydantic>=2.11.4",
+    "rich>=13.9.4",
     "wrapt>=1.17.2",
 ]
 

--- a/src/atla_insights/__init__.py
+++ b/src/atla_insights/__init__.py
@@ -1,7 +1,5 @@
 """Atla package for PyPI distribution."""
 
-from logfire import instrument
-
 from atla_insights.frameworks import (
     instrument_agno,
     instrument_crewai,
@@ -16,6 +14,7 @@ from atla_insights.frameworks import (
     uninstrument_openai_agents,
     uninstrument_smolagents,
 )
+from atla_insights.instrument import instrument
 from atla_insights.llm_providers import (
     instrument_anthropic,
     instrument_google_genai,

--- a/src/atla_insights/console_span_exporter.py
+++ b/src/atla_insights/console_span_exporter.py
@@ -1,0 +1,176 @@
+"""Console span exporter."""
+
+import os
+import sys
+from collections.abc import Sequence
+from datetime import datetime, timezone
+from textwrap import indent as indent_text
+from typing import List, Literal, Optional, TextIO, Tuple, cast
+
+from opentelemetry.sdk.trace import Event, ReadableSpan
+from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+from rich.console import Console, Group
+from rich.syntax import Syntax
+from rich.text import Text
+
+ConsoleColorsValues = Literal["auto", "always", "never"]
+ONE_SECOND_IN_NANOSECONDS = 1_000_000_000
+TextParts = List[Tuple[str, str]]
+
+
+class ConsoleSpanExporter(SpanExporter):
+    """The ConsoleSpanExporter prints spans to the console."""
+
+    def __init__(
+        self,
+        output: TextIO | None = None,
+        colors: ConsoleColorsValues = "auto",
+        include_timestamp: bool = True,
+    ) -> None:
+        """Initialize the ConsoleSpanExporter.
+
+        :param output (TextIO | None): The output stream to write to.
+            Defaults to `sys.stdout`.
+        :param colors (ConsoleColorsValues): The color mode to use. Defaults to `"auto"`.
+        :param include_timestamp (bool): Whether to include the timestamp in the output.
+            Defaults to `True`.
+        """
+        self._output = output or sys.stdout
+        if colors == "auto":
+            force_terminal = None
+        else:
+            force_terminal = colors == "always"
+        self._console: Optional[Console] = Console(
+            color_system="standard" if os.environ.get("PYTEST_VERSION") else "auto",
+            file=self._output,
+            force_terminal=force_terminal,
+            highlight=False,
+            markup=False,
+            soft_wrap=True,
+        )
+        if not self._console.is_terminal:
+            self._console = None
+
+        self._include_timestamp = include_timestamp
+        self._timestamp_indent = 13 if include_timestamp else 0
+
+    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+        """Export the spans to the console."""
+        span_id_to_span = {span.context.span_id: span for span in spans if span.context}
+        indent_cache: dict[int, int] = {}
+
+        def get_indent_level(span: ReadableSpan) -> int:
+            if not span.context:
+                return 0
+
+            span_id = span.context.span_id
+
+            if span_id in indent_cache:
+                return indent_cache[span_id]
+
+            level = 0
+            current = span
+            path = []
+
+            while current.parent is not None:
+                parent_span = span_id_to_span.get(current.parent.span_id)
+                if parent_span is None:
+                    level += 1
+                    break
+
+                if not parent_span.context:
+                    break
+
+                parent_id = parent_span.context.span_id
+                if parent_id in indent_cache:
+                    level += indent_cache[parent_id] + 1
+                    break
+
+                if current.context:
+                    path.append((current.context.span_id, level))
+                current = parent_span
+                level += 1
+
+            indent_cache[span_id] = level
+
+            for path_span_id, path_level in reversed(path):
+                if path_span_id not in indent_cache:
+                    indent_cache[path_span_id] = level - path_level
+
+            return level
+
+        for span in sorted(spans, key=lambda s: s.start_time or 0):
+            indent_level = get_indent_level(span)
+            self._print_span(span, indent_level)
+
+        return SpanExportResult.SUCCESS
+
+    def _print_span(self, span: ReadableSpan, indent: int = 0):
+        """Build up a summary of the span, including formatting for rich, then print it.
+
+        :param span (ReadableSpan): The span to print.
+        :param indent (int): The indent level. Defaults to `0`.
+        """
+        _msg, parts = self._span_text_parts(span, indent)
+
+        indent_str = (self._timestamp_indent + indent * 2) * " "
+
+        if self._console:
+            self._console.print(Text.assemble(*parts))
+        else:
+            print("".join(text for text, _style in parts), file=self._output)
+
+        exc_event = next(
+            (event for event in span.events or [] if event.name == "exception"), None
+        )
+        self._print_exc_info(exc_event, indent_str)
+
+    def _span_text_parts(self, span: ReadableSpan, indent: int) -> tuple[str, TextParts]:
+        """Return the formatted message or span name and parts containing basic span info.
+
+        The following information is included:
+        * timestamp
+        * message (maybe indented)
+        * tags (if `self._include_tags` is True)
+
+        The log level may be indicated by the color of the message.
+        """
+        parts: TextParts = []
+        if self._include_timestamp:
+            ts = datetime.fromtimestamp(
+                (span.start_time or 0) / ONE_SECOND_IN_NANOSECONDS, tz=timezone.utc
+            )
+            ts_str = f"{ts:%H:%M:%S.%f}"[:-3]
+            parts += [(ts_str, "green"), (" ", "")]
+
+        if indent:
+            parts += [(indent * "  ", "")]
+
+        parts += [(span.name or "Unnamed Span", "")]
+
+        return span.name, parts
+
+    def _print_exc_info(self, exc_event: Event | None, indent_str: str) -> None:
+        """Print exception information if an exception event is present."""
+        if exc_event is None or not exc_event.attributes:
+            return
+
+        exc_type = cast(str, exc_event.attributes.get("exception.type"))
+        exc_msg = cast(str, exc_event.attributes.get("exception.message"))
+        exc_tb = cast(str, exc_event.attributes.get("exception.stacktrace"))
+
+        if self._console:
+            barrier = Text(indent_str + "│ ", style="blue", end="")
+            exc_type_rich = Text(f"{exc_type}: ", end="", style="bold red")
+            exc_msg_rich = Text(exc_msg)
+            indented_code = indent_text(exc_tb, indent_str + "│ ")
+            exc_tb_rich = Syntax(indented_code, "python", background_color="default")
+            self._console.print(Group(barrier, exc_type_rich, exc_msg_rich), exc_tb_rich)
+        else:
+            out = [f"{indent_str}│ {exc_type}: {exc_msg}"]
+            out += [indent_text(exc_tb, indent_str + "│ ")]
+            print("\n".join(out), file=self._output)
+
+    def force_flush(self, timeout_millis: int = 0) -> bool:  # pragma: no cover
+        """Force flush all spans, does nothing for this exporter."""
+        return True

--- a/src/atla_insights/console_span_exporter.py
+++ b/src/atla_insights/console_span_exporter.py
@@ -126,7 +126,12 @@ class ConsoleSpanExporter(SpanExporter):
         self._print_exc_info(exc_event, indent_str)
 
     def _span_text_parts(self, span: ReadableSpan, indent: int) -> tuple[str, TextParts]:
-        """Return the formatted message or span name and parts containing basic span info.
+        """Build up a summary of the span, including formatting for rich, then print it.
+
+        :param span (ReadableSpan): The span to print.
+        :param indent (int): The indent level. Defaults to `0`.
+        :return (tuple[str, TextParts]): The formatted message or span name and parts
+        containing basic span information.
 
         The following information is included:
         * timestamp
@@ -151,7 +156,11 @@ class ConsoleSpanExporter(SpanExporter):
         return span.name, parts
 
     def _print_exc_info(self, exc_event: Event | None, indent_str: str) -> None:
-        """Print exception information if an exception event is present."""
+        """Print exception information if an exception event is present.
+
+        :param exc_event (Event | None): The exception event to print.
+        :param indent_str (str): The indent string.
+        """
         if exc_event is None or not exc_event.attributes:
             return
 

--- a/src/atla_insights/console_span_exporter.py
+++ b/src/atla_insights/console_span_exporter.py
@@ -109,7 +109,7 @@ class ConsoleSpanExporter(SpanExporter):
         """Build up a summary of the span, including formatting for rich, then print it.
 
         :param span (ReadableSpan): The span to print.
-        :param indent (int): The indent level. Defaults to `0`.
+        :param indent (int): The indent level. Defaults to 0.
         """
         _msg, parts = self._span_text_parts(span, indent)
 
@@ -117,7 +117,7 @@ class ConsoleSpanExporter(SpanExporter):
 
         if self._console:
             self._console.print(Text.assemble(*parts))
-        else:
+        elif self._output and not self._output.closed:
             print("".join(text for text, _style in parts), file=self._output)
 
         exc_event = next(
@@ -175,11 +175,11 @@ class ConsoleSpanExporter(SpanExporter):
             indented_code = indent_text(exc_tb, indent_str + "│ ")
             exc_tb_rich = Syntax(indented_code, "python", background_color="default")
             self._console.print(Group(barrier, exc_type_rich, exc_msg_rich), exc_tb_rich)
-        else:
+        elif self._output and not self._output.closed:
             out = [f"{indent_str}│ {exc_type}: {exc_msg}"]
             out += [indent_text(exc_tb, indent_str + "│ ")]
             print("\n".join(out), file=self._output)
 
-    def force_flush(self, timeout_millis: int = 0) -> bool:  # pragma: no cover
+    def force_flush(self, timeout_millis: int = 0) -> bool:
         """Force flush all spans, does nothing for this exporter."""
         return True

--- a/src/atla_insights/constants.py
+++ b/src/atla_insights/constants.py
@@ -11,7 +11,8 @@ MAX_METADATA_VALUE_CHARS = 100
 METADATA_MARK = "atla.metadata"
 SUCCESS_MARK = "atla.mark.success"
 
-LOGFIRE_OTEL_TRACES_ENDPOINT = "https://logfire-eu.pydantic.dev/v1/traces"
+OTEL_MODULE_NAME = "atla_insights"
+OTEL_TRACES_ENDPOINT = "https://logfire-eu.pydantic.dev/v1/traces"
 
 SUPPORTED_LLM_PROVIDER = Literal["anthropic", "google-genai", "litellm", "openai"]
 LLM_PROVIDER_TYPE = Union[Sequence[SUPPORTED_LLM_PROVIDER], SUPPORTED_LLM_PROVIDER]

--- a/src/atla_insights/frameworks/instrumentors/agno.py
+++ b/src/atla_insights/frameworks/instrumentors/agno.py
@@ -7,7 +7,7 @@ try:
 except ImportError as e:
     raise ImportError(
         "Agno instrumentation needs to be installed. "
-        "Please install it via `pip install atla-insights[agno]`."
+        'Please install it via `pip install "atla-insights[agno]"`.'
     ) from e
 
 

--- a/src/atla_insights/frameworks/instrumentors/crewai.py
+++ b/src/atla_insights/frameworks/instrumentors/crewai.py
@@ -26,7 +26,7 @@ try:
 except ImportError as e:
     raise ImportError(
         "CrewAI instrumentation needs to be installed. "
-        "Please install it via `pip install atla-insights[crewai]`."
+        'Please install it via `pip install "atla-insights[crewai]"`.'
     ) from e
 
 

--- a/src/atla_insights/frameworks/instrumentors/langchain.py
+++ b/src/atla_insights/frameworks/instrumentors/langchain.py
@@ -12,7 +12,7 @@ try:
 except ImportError as e:
     raise ImportError(
         "LangChain instrumentation needs to be installed. "
-        "Please install it via `pip install atla-insights[langchain]`."
+        'Please install it via `pip install "atla-insights[langchain]"`.'
     ) from e
 
 

--- a/src/atla_insights/frameworks/instrumentors/openai_agents.py
+++ b/src/atla_insights/frameworks/instrumentors/openai_agents.py
@@ -11,7 +11,7 @@ try:
 except ImportError as e:
     raise ImportError(
         "OpenAI agents instrumentation needs to be installed. "
-        "Please install it via `pip install atla-insights[openai-agents]`."
+        'Please install it via `pip install "atla-insights[openai-agents]"`.'
     ) from e
 
 

--- a/src/atla_insights/frameworks/instrumentors/smolagents.py
+++ b/src/atla_insights/frameworks/instrumentors/smolagents.py
@@ -23,7 +23,7 @@ try:
 except ImportError as e:
     raise ImportError(
         "SmolAgents instrumentation needs to be installed. "
-        "Please install it via `pip install atla-insights[smolagents]`."
+        'Please install it via `pip install "atla-insights[smolagents]"`.'
     ) from e
 
 

--- a/src/atla_insights/frameworks/mcp.py
+++ b/src/atla_insights/frameworks/mcp.py
@@ -32,7 +32,7 @@ def instrument_mcp() -> ContextManager[None]:
     except ImportError as e:
         raise ImportError(
             "MCP instrumentation needs to be installed. "
-            "Please install it via `pip install atla-insights[mcp]`."
+            'Please install it via `pip install "atla-insights[mcp]"`.'
         ) from e
 
     return ATLA_INSTANCE.instrument_service(

--- a/src/atla_insights/frameworks/utils.py
+++ b/src/atla_insights/frameworks/utils.py
@@ -31,7 +31,7 @@ def get_instrumentors_for_provider(
                 except ImportError as e:
                     raise ImportError(
                         "Anthropic instrumentation needs to be installed. "
-                        "Please install it via `pip install atla-insights[anthropic]`."
+                        'Please install it via `pip install "atla-insights[anthropic]"`.'
                     ) from e
 
                 instrumentors.append(AnthropicInstrumentor())
@@ -53,7 +53,7 @@ def get_instrumentors_for_provider(
                 except ImportError as e:
                     raise ImportError(
                         "OpenAI instrumentation needs to be installed. "
-                        "Please install it via `pip install atla-insights[openai]`."
+                        'Please install it via `pip install "atla-insights[openai]"`.'
                     ) from e
 
                 instrumentors.append(OpenAIInstrumentor())

--- a/src/atla_insights/instrument.py
+++ b/src/atla_insights/instrument.py
@@ -1,0 +1,110 @@
+"""Instrument functions."""
+
+import functools
+import inspect
+from typing import Any, AsyncGenerator, Callable, Generator, Optional, overload
+
+from atla_insights.main import ATLA_INSTANCE, AtlaInsights, logger
+
+
+@overload
+def instrument(func_or_message: Callable) -> Callable: ...
+
+
+@overload
+def instrument(func_or_message: Optional[str] = None) -> Callable: ...
+
+
+def instrument(func_or_message: Callable | Optional[str] = None) -> Callable:
+    """Instruments a regular Python function.
+
+    Can be used as either:
+    ```py
+    from atla_insights import instrument
+
+    @instrument
+    def my_function(a: int):
+        ...
+    ```
+
+    or
+
+    ```py
+    from atla_insights import instrument
+
+    @instrument("My function")
+    def my_function(a: int):
+        ...
+    ```
+    """
+    if callable(func_or_message):
+        return instrument()(func=func_or_message)
+    return _instrument(atla_instance=ATLA_INSTANCE, message=func_or_message)
+
+
+def _instrument(atla_instance: AtlaInsights, message: Optional[str]) -> Callable:
+    """Instrument a function.
+
+    :param tracer (Optional[Tracer]): The tracer to use for instrumentation.
+    :param message (Optional[str]): The message to use for the span.
+    :return (Callable): A decorator that instruments the function.
+    """
+
+    def decorator(func: Callable) -> Callable:
+        if inspect.isgeneratorfunction(func):
+
+            @functools.wraps(func)
+            def gen_wrapper(*args, **kwargs) -> Generator[Any, Any, Any]:
+                if atla_instance.tracer is None:
+                    logger.error("Atla insights not configured, skipping instrumentation")
+                    yield from func(*args, **kwargs)
+                else:
+                    with atla_instance.tracer.start_as_current_span(
+                        message or func.__qualname__
+                    ):
+                        yield from func(*args, **kwargs)
+
+            return gen_wrapper
+
+        elif inspect.isasyncgenfunction(func):
+
+            @functools.wraps(func)
+            async def async_gen_wrapper(*args, **kwargs) -> AsyncGenerator[Any, Any]:
+                if atla_instance.tracer is None:
+                    logger.error("Atla insights not configured, skipping instrumentation")
+                    async for x in func(*args, **kwargs):
+                        yield x
+                else:
+                    with atla_instance.tracer.start_as_current_span(
+                        message or func.__qualname__
+                    ):
+                        async for x in func(*args, **kwargs):
+                            yield x
+
+            return async_gen_wrapper
+
+        elif inspect.iscoroutinefunction(func):
+
+            @functools.wraps(func)
+            async def async_wrapper(*args, **kwargs) -> Any:
+                if atla_instance.tracer is None:
+                    logger.error("Atla insights not configured, skipping instrumentation")
+                    return await func(*args, **kwargs)
+                with atla_instance.tracer.start_as_current_span(
+                    message or func.__qualname__
+                ):
+                    return await func(*args, **kwargs)
+
+            return async_wrapper
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs) -> Any:
+            if atla_instance.tracer is None:
+                logger.error("Atla insights not configured, skipping instrumentation")
+                return func(*args, **kwargs)
+            with atla_instance.tracer.start_as_current_span(message or func.__qualname__):
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/src/atla_insights/instrument.py
+++ b/src/atla_insights/instrument.py
@@ -56,7 +56,7 @@ def _instrument(atla_instance: AtlaInsights, message: Optional[str]) -> Callable
             @functools.wraps(func)
             def gen_wrapper(*args, **kwargs) -> Generator[Any, Any, Any]:
                 if atla_instance.tracer is None:
-                    logger.error("Atla insights not configured, skipping instrumentation")
+                    logger.error("Atla Insights not configured, skipping instrumentation")
                     yield from func(*args, **kwargs)
                 else:
                     with atla_instance.tracer.start_as_current_span(
@@ -71,7 +71,7 @@ def _instrument(atla_instance: AtlaInsights, message: Optional[str]) -> Callable
             @functools.wraps(func)
             async def async_gen_wrapper(*args, **kwargs) -> AsyncGenerator[Any, Any]:
                 if atla_instance.tracer is None:
-                    logger.error("Atla insights not configured, skipping instrumentation")
+                    logger.error("Atla Insights not configured, skipping instrumentation")
                     async for x in func(*args, **kwargs):
                         yield x
                 else:
@@ -88,7 +88,7 @@ def _instrument(atla_instance: AtlaInsights, message: Optional[str]) -> Callable
             @functools.wraps(func)
             async def async_wrapper(*args, **kwargs) -> Any:
                 if atla_instance.tracer is None:
-                    logger.error("Atla insights not configured, skipping instrumentation")
+                    logger.error("Atla Insights not configured, skipping instrumentation")
                     return await func(*args, **kwargs)
                 with atla_instance.tracer.start_as_current_span(
                     message or func.__qualname__
@@ -100,7 +100,7 @@ def _instrument(atla_instance: AtlaInsights, message: Optional[str]) -> Callable
         @functools.wraps(func)
         def wrapper(*args, **kwargs) -> Any:
             if atla_instance.tracer is None:
-                logger.error("Atla insights not configured, skipping instrumentation")
+                logger.error("Atla Insights not configured, skipping instrumentation")
                 return func(*args, **kwargs)
             with atla_instance.tracer.start_as_current_span(message or func.__qualname__):
                 return func(*args, **kwargs)

--- a/src/atla_insights/llm_providers/anthropic.py
+++ b/src/atla_insights/llm_providers/anthropic.py
@@ -25,7 +25,7 @@ def instrument_anthropic() -> ContextManager[None]:
     except ImportError as e:
         raise ImportError(
             "Anthropic instrumentation needs to be installed. "
-            "Please install it via `pip install atla-insights[anthropic]`."
+            'Please install it via `pip install "atla-insights[anthropic]"`.'
         ) from e
 
     anthropic_instrumentor = AnthropicInstrumentor()

--- a/src/atla_insights/llm_providers/instrumentors/google_genai.py
+++ b/src/atla_insights/llm_providers/instrumentors/google_genai.py
@@ -24,7 +24,7 @@ try:
 except ImportError as e:
     raise ImportError(
         "Google GenAI instrumentation needs to be installed. "
-        "Please install it via `pip install atla-insights[google-genai]`."
+        'Please install it via `pip install "atla-insights[google-genai]"`.'
     ) from e
 
 

--- a/src/atla_insights/llm_providers/instrumentors/litellm.py
+++ b/src/atla_insights/llm_providers/instrumentors/litellm.py
@@ -14,7 +14,7 @@ try:
 except ImportError as e:
     raise ImportError(
         "Litellm needs to be installed. "
-        "Please install it via `pip install atla-insights[litellm]`."
+        'Please install it via `pip install "atla-insights[litellm]"`.'
     ) from e
 
 from opentelemetry import trace

--- a/src/atla_insights/llm_providers/openai.py
+++ b/src/atla_insights/llm_providers/openai.py
@@ -25,7 +25,7 @@ def instrument_openai() -> ContextManager[None]:
     except ImportError as e:
         raise ImportError(
             "OpenAI instrumentation needs to be installed. "
-            "Please install it via `pip install atla-insights[openai]`."
+            'Please install it via `pip install "atla-insights[openai]"`.'
         ) from e
 
     openai_instrumentor = OpenAIInstrumentor()

--- a/src/atla_insights/main.py
+++ b/src/atla_insights/main.py
@@ -69,7 +69,7 @@ class AtlaInsights:
         ]
 
         if verbose:
-            span_processors.append(get_atla_console_span_processor(logger))
+            span_processors.append(get_atla_console_span_processor())
 
         self.tracer_provider = self._setup_tracer_provider()
         self.tracer = self.tracer_provider.get_tracer(OTEL_MODULE_NAME)

--- a/src/atla_insights/main.py
+++ b/src/atla_insights/main.py
@@ -83,7 +83,7 @@ class AtlaInsights:
     def _setup_tracer_provider(self) -> TracerProvider:
         """Setup the tracer provider.
 
-        If a (non-proxy) tracer provider is already set, we return it. All Alta-specific
+        If a (non-proxy) tracer provider is already set, we return it. All Atla-specific
         telemetry will be added to the existing functionality attached to this tracer
         provider.
 

--- a/src/atla_insights/main.py
+++ b/src/atla_insights/main.py
@@ -1,26 +1,27 @@
 """Core functionality for the atla_insights package."""
 
-import importlib
 import logging
 import os
 from contextlib import contextmanager
 from typing import ContextManager, Optional, Sequence
 
-import logfire
-import opentelemetry.trace
 from opentelemetry import trace
 from opentelemetry.instrumentation.instrumentor import (  # type: ignore[attr-defined]
     BaseInstrumentor,
 )
 from opentelemetry.sdk.environment_variables import OTEL_ATTRIBUTE_COUNT_LIMIT
-from opentelemetry.sdk.trace import SpanProcessor
-from opentelemetry.trace import Tracer, TracerProvider
+from opentelemetry.sdk.trace import SpanProcessor, TracerProvider
+from opentelemetry.trace import ProxyTracerProvider, Tracer
 
-from atla_insights.constants import DEFAULT_OTEL_ATTRIBUTE_COUNT_LIMIT
+from atla_insights.constants import DEFAULT_OTEL_ATTRIBUTE_COUNT_LIMIT, OTEL_MODULE_NAME
 from atla_insights.metadata import set_metadata
-from atla_insights.span_processors import AtlaRootSpanProcessor, get_atla_span_processor
+from atla_insights.span_processors import (
+    AtlaRootSpanProcessor,
+    get_atla_console_span_processor,
+    get_atla_span_processor,
+)
 
-logger = logging.getLogger("atla_insights")
+logger = logging.getLogger(OTEL_MODULE_NAME)
 
 
 # Override the OTEL default attribute count limit (128), if not user-specified. This is
@@ -57,8 +58,6 @@ class AtlaInsights:
         :param verbose (bool): Whether to print verbose output to console.
             Defaults to `True`.
         """
-        self._maybe_reset_tracer_provider()
-
         if metadata is not None:
             set_metadata(metadata)
 
@@ -69,27 +68,38 @@ class AtlaInsights:
             *additional_span_processors,
         ]
 
-        logfire_instance = logfire.configure(
-            additional_span_processors=span_processors,
-            console=None if verbose else False,
-            environment=os.getenv("_ATLA_ENV", "prod"),
-            send_to_logfire=False,
-            scrubbing=False,
-        )
-        self.tracer = logfire_instance._get_tracer(is_span_tracer=True)
-        self.configured = True
+        if verbose:
+            span_processors.append(get_atla_console_span_processor(logger))
 
+        self.tracer_provider = self._setup_tracer_provider()
+        self.tracer = self.tracer_provider.get_tracer(OTEL_MODULE_NAME)
+
+        for processor in span_processors:
+            self.tracer_provider.add_span_processor(processor)
+
+        self.configured = True
         logger.info("Atla insights configured correctly ✅")
 
-    def _maybe_reset_tracer_provider(self) -> None:
-        """Reset the existing OpenTelemetry tracer provider, if one exists.
+    def _setup_tracer_provider(self) -> TracerProvider:
+        """Setup the tracer provider.
 
-        Removes any existing tracer provider to allow the Atla tracer provider to get
-        initialized correctly. OpenTelemetry tracer providers cannot be re-initialized, so
-        we need to reload the module.
+        If a (non-proxy) tracer provider is already set, we return it. All Alta-specific
+        telemetry will be added to the existing functionality attached to this tracer
+        provider.
+
+        If no tracer provider is set, we create a new one and set it as the global tracer
+        provider.
+
+        :return (TracerProvider): The tracer provider.
         """
-        if isinstance(trace.get_tracer_provider(), TracerProvider):
-            importlib.reload(opentelemetry.trace)
+        _existing_tracer_provider = trace.get_tracer_provider()
+        if isinstance(_existing_tracer_provider, ProxyTracerProvider) or not isinstance(
+            _existing_tracer_provider, TracerProvider
+        ):
+            new_tracer_provider = TracerProvider()
+            trace.set_tracer_provider(new_tracer_provider)
+            return new_tracer_provider
+        return _existing_tracer_provider
 
     def instrument_service(
         self, service: str, instrumentors: Sequence[BaseInstrumentor]

--- a/src/atla_insights/span_processors.py
+++ b/src/atla_insights/span_processors.py
@@ -1,15 +1,14 @@
 """Span processors."""
 
 import json
-import logging
 from typing import Optional
 
-from logfire._internal.exporters.console import ShowParentsConsoleSpanExporter
 from opentelemetry.context import Context
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
-from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor
 
+from atla_insights.console_span_exporter import ConsoleSpanExporter
 from atla_insights.constants import METADATA_MARK, OTEL_TRACES_ENDPOINT, SUCCESS_MARK
 from atla_insights.context import metadata_var, root_span_var
 
@@ -46,10 +45,10 @@ def get_atla_span_processor(token: str) -> SpanProcessor:
     return SimpleSpanProcessor(span_exporter)
 
 
-def get_atla_console_span_processor(logger: logging.Logger) -> SpanProcessor:
+def get_atla_console_span_processor() -> BatchSpanProcessor:
     """Get an Atla console span processor.
 
-    :return (SpanProcessor): An Atla console span processor.
+    :return (BatchSpanProcessor): An Atla console span processor.
     """
-    span_exporter = ShowParentsConsoleSpanExporter()
-    return SimpleSpanProcessor(span_exporter)
+    span_exporter = ConsoleSpanExporter()
+    return BatchSpanProcessor(span_exporter)

--- a/src/atla_insights/span_processors.py
+++ b/src/atla_insights/span_processors.py
@@ -1,18 +1,16 @@
 """Span processors."""
 
 import json
+import logging
 from typing import Optional
 
+from logfire._internal.exporters.console import ShowParentsConsoleSpanExporter
 from opentelemetry.context import Context
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 
-from atla_insights.constants import (
-    LOGFIRE_OTEL_TRACES_ENDPOINT,
-    METADATA_MARK,
-    SUCCESS_MARK,
-)
+from atla_insights.constants import METADATA_MARK, OTEL_TRACES_ENDPOINT, SUCCESS_MARK
 from atla_insights.context import metadata_var, root_span_var
 
 
@@ -42,7 +40,16 @@ def get_atla_span_processor(token: str) -> SpanProcessor:
     :return (SpanProcessor): An Atla span processor.
     """
     span_exporter = OTLPSpanExporter(
-        endpoint=LOGFIRE_OTEL_TRACES_ENDPOINT,
+        endpoint=OTEL_TRACES_ENDPOINT,
         headers={"Authorization": f"Bearer {token}"},
     )
+    return SimpleSpanProcessor(span_exporter)
+
+
+def get_atla_console_span_processor(logger: logging.Logger) -> SpanProcessor:
+    """Get an Atla console span processor.
+
+    :return (SpanProcessor): An Atla console span processor.
+    """
+    span_exporter = ShowParentsConsoleSpanExporter()
     return SimpleSpanProcessor(span_exporter)

--- a/src/atla_insights/utils.py
+++ b/src/atla_insights/utils.py
@@ -1,0 +1,24 @@
+"""Utility functions for Atla Insights."""
+
+import importlib
+
+import opentelemetry.trace
+from opentelemetry.sdk.trace import TracerProvider as SDKTracerProvider
+from opentelemetry.trace import ProxyTracerProvider, get_tracer_provider
+
+
+def maybe_get_existing_tracer_provider() -> SDKTracerProvider | None:
+    """Get the existing tracer provider, if it exists."""
+    existing_tracer_provider = get_tracer_provider()
+
+    # If the existing tracer provider is a proxy, there is no existing OTEL setup.
+    if isinstance(existing_tracer_provider, ProxyTracerProvider):
+        return None
+
+    # If there is an API tracer provider, but not an SDK tracer provider, it is a no-op
+    # and we reload the module so we can reset the tracer provider safely.
+    if not isinstance(existing_tracer_provider, SDKTracerProvider):
+        importlib.reload(opentelemetry.trace)
+        return None
+
+    return existing_tracer_provider

--- a/tests/frameworks/test_crewai.py
+++ b/tests/frameworks/test_crewai.py
@@ -32,12 +32,14 @@ class TestCrewAIInstrumentation(BaseLocalOtel):
 
         finished_spans = self.get_finished_spans()
 
-        assert len(finished_spans) == 3
+        assert len(finished_spans) == 5
 
-        kickoff, execute, request = finished_spans
+        kickoff, crew_create, execute, task_create, request = finished_spans
 
         assert kickoff.name == "Crew.kickoff"
+        assert crew_create.name == "Crew Created"
         assert execute.name == "Task._execute_core"
+        assert task_create.name == "Task Created"
         assert request.name == "litellm_request"
 
         assert request.attributes is not None
@@ -70,12 +72,14 @@ class TestCrewAIInstrumentation(BaseLocalOtel):
 
         finished_spans = self.get_finished_spans()
 
-        assert len(finished_spans) == 3
+        assert len(finished_spans) == 5
 
-        kickoff, execute, request = finished_spans
+        kickoff, crew_create, execute, task_create, request = finished_spans
 
         assert kickoff.name == "Crew.kickoff"
+        assert crew_create.name == "Crew Created"
         assert execute.name == "Task._execute_core"
+        assert task_create.name == "Task Created"
         assert request.name == "litellm_request"
 
         assert request.attributes is not None
@@ -110,12 +114,14 @@ class TestCrewAIInstrumentation(BaseLocalOtel):
 
         finished_spans = self.get_finished_spans()
 
-        assert len(finished_spans) == 3
+        assert len(finished_spans) == 7
 
-        kickoff, execute, request = finished_spans
+        kickoff, crew_create, execute, task_create, request, _, _ = finished_spans
 
         assert kickoff.name == "Crew.kickoff"
+        assert crew_create.name == "Crew Created"
         assert execute.name == "Task._execute_core"
+        assert task_create.name == "Task Created"
         assert request.name == "litellm_request"
 
     def test_tool_invocation(self) -> None:
@@ -142,11 +148,13 @@ class TestCrewAIInstrumentation(BaseLocalOtel):
             tool_usage._use("test_function", tool, tool_calling)
 
         finished_spans = self.get_finished_spans()
-        assert len(finished_spans) == 1
 
-        [span] = finished_spans
+        assert len(finished_spans) == 2
+
+        span, tool_usage_span = finished_spans
 
         assert span.name == "test_function"
+        assert tool_usage_span.name == "Tool Usage"
 
         assert span.attributes is not None
         assert span.attributes.get("openinference.span.kind") == "TOOL"

--- a/tests/llm_providers/test_litellm.py
+++ b/tests/llm_providers/test_litellm.py
@@ -32,7 +32,7 @@ class TestLitellmInstrumentation(BaseLocalOtel):
         [litellm_request] = spans
 
         assert litellm_request.attributes is not None
-        assert litellm_request.attributes.get("logfire.msg") == "litellm_request"
+        assert litellm_request.attributes.get("atla.instrumentation.name") == "litellm"
         assert litellm_request.attributes.get(SUCCESS_MARK) == -1
 
     @pytest.mark.asyncio
@@ -55,7 +55,7 @@ class TestLitellmInstrumentation(BaseLocalOtel):
         [litellm_request] = spans
 
         assert litellm_request.attributes is not None
-        assert litellm_request.attributes.get("logfire.msg") == "litellm_request"
+        assert litellm_request.attributes.get("atla.instrumentation.name") == "litellm"
         assert litellm_request.attributes.get(SUCCESS_MARK) == -1
 
     @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -1804,7 +1804,7 @@ wheels = [
 
 [[package]]
 name = "logfire"
-version = "3.21.1"
+version = "3.21.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "executing" },
@@ -1816,9 +1816,9 @@ dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/89/58/cf07fae73c1eccb34d44904451c4a62fc05df21754ce80621ed8235e07ed/logfire-3.21.1.tar.gz", hash = "sha256:421b7741cfe3c02f2f0c91159a35312d3f3a4aa0d855af01c958d0e243472367", size = 489303, upload-time = "2025-06-18T12:57:40.935Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/2c/1fcb1440accbace48df3151a559f1d082e905d2ca4da6848c1d74cbc11e9/logfire-3.21.2.tar.gz", hash = "sha256:81ade93399b156bee0bd0d89ef921b2fb90034217960725598745941d6c36da4", size = 490071, upload-time = "2025-06-30T13:49:52.613Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/d1/7e51d3a5c8dd90897d2e0ca36d1195b0fc7e9d0afc04a7cd1aacaaa95e52/logfire-3.21.1-py3-none-any.whl", hash = "sha256:baecd3ec189e76c95775612a66ab23fe6d3fee53d5a4fa60dce42082370cdd4c", size = 201333, upload-time = "2025-06-18T12:57:37.676Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/b4/185e335ce772ed1b0004993ef456742119e88fe0a0ee196d8b4452fdc222/logfire-3.21.2-py3-none-any.whl", hash = "sha256:a08bc6a3b3dcbf98dd27067325ea3d178e6e046fe0d7f8e63e971db52d317e70", size = 201619, upload-time = "2025-06-30T13:49:49.446Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -212,7 +212,6 @@ name = "atla-insights"
 version = "0.0.1"
 source = { editable = "." }
 dependencies = [
-    { name = "logfire" },
     { name = "openai" },
     { name = "openinference-instrumentation" },
     { name = "openinference-semantic-conventions" },
@@ -312,7 +311,6 @@ requires-dist = [
     { name = "langgraph", marker = "extra == 'langchain'", specifier = ">=0.3.20" },
     { name = "litellm", marker = "extra == 'crewai'", specifier = ">=1.72.0" },
     { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.72.0" },
-    { name = "logfire", specifier = ">=3.14.1" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.9.0" },
     { name = "mypy", marker = "extra == 'ci'", specifier = ">=1.15.0" },
     { name = "openai", specifier = ">=1.77.0" },
@@ -1800,25 +1798,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/d3/f1a8c9c9ffdd3bab1bc410254c8140b1346f05a01b8c6b37c48b56abb4b0/litellm-1.72.0.tar.gz", hash = "sha256:135022b9b8798f712ffa84e71ac419aa4310f1d0a70f79dd2007f7ef3a381e43", size = 8082337, upload-time = "2025-06-01T02:12:54.203Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/98/bec08f5a3e504013db6f52b5fd68375bd92b463c91eb454d5a6460e957af/litellm-1.72.0-py3-none-any.whl", hash = "sha256:88360a7ae9aa9c96278ae1bb0a459226f909e711c5d350781296d0640386a824", size = 7979630, upload-time = "2025-06-01T02:12:50.458Z" },
-]
-
-[[package]]
-name = "logfire"
-version = "3.21.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "executing" },
-    { name = "opentelemetry-exporter-otlp-proto-http" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-sdk" },
-    { name = "protobuf" },
-    { name = "rich" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/2c/1fcb1440accbace48df3151a559f1d082e905d2ca4da6848c1d74cbc11e9/logfire-3.21.2.tar.gz", hash = "sha256:81ade93399b156bee0bd0d89ef921b2fb90034217960725598745941d6c36da4", size = 490071, upload-time = "2025-06-30T13:49:52.613Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/b4/185e335ce772ed1b0004993ef456742119e88fe0a0ee196d8b4452fdc222/logfire-3.21.2-py3-none-any.whl", hash = "sha256:a08bc6a3b3dcbf98dd27067325ea3d178e6e046fe0d7f8e63e971db52d317e70", size = 201619, upload-time = "2025-06-30T13:49:49.446Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -218,6 +218,7 @@ dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
     { name = "pydantic" },
+    { name = "rich" },
     { name = "wrapt" },
 ]
 
@@ -333,6 +334,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'ci'", specifier = ">=8.3.4" },
     { name = "pytest-asyncio", marker = "extra == 'ci'", specifier = ">=0.26.0" },
     { name = "pytest-httpserver", marker = "extra == 'ci'", specifier = ">=1.1.3" },
+    { name = "rich", specifier = ">=13.9.4" },
     { name = "ruff", marker = "extra == 'ci'", specifier = ">=0.11.7" },
     { name = "smolagents", marker = "extra == 'smolagents'", specifier = ">=1.17.0" },
     { name = "wrapt", specifier = ">=1.17.2" },


### PR DESCRIPTION
- Ensures compatibility with other OTEL providers/instrumentation by checking for existing OTEL providers. If there are any, we add onto it. If there are none, we create a new provider
- Replace logfire instrumentation by plain OTEL instrumentation because logfire configure will always try to replace existing telemetry