### PR TITLE
Implement custom ID generator

### DIFF
--- a/src/atla_insights/id_generator.py
+++ b/src/atla_insights/id_generator.py
@@ -1,0 +1,26 @@
+"""Custom OpenTelemetry ID generator."""
+
+import random
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace.id_generator import RandomIdGenerator
+
+
+class NoSeedIdGenerator(RandomIdGenerator):
+    """Custom OpenTelemetry ID generator, uninfluenced by any pre-existing random seed."""
+
+    rng = random.Random()
+
+    def generate_span_id(self) -> int:
+        """Generate a span ID."""
+        span_id = self.rng.getrandbits(64)
+        while span_id == trace.INVALID_SPAN_ID:
+            span_id = self.rng.getrandbits(64)
+        return span_id
+
+    def generate_trace_id(self) -> int:
+        """Generate a trace ID."""
+        trace_id = self.rng.getrandbits(128)
+        while trace_id == trace.INVALID_TRACE_ID:
+            trace_id = self.rng.getrandbits(128)
+        return trace_id

--- a/src/atla_insights/main.py
+++ b/src/atla_insights/main.py
@@ -13,6 +13,7 @@ from opentelemetry.sdk.trace import SpanProcessor, TracerProvider
 from opentelemetry.trace import Tracer, set_tracer_provider
 
 from atla_insights.constants import DEFAULT_OTEL_ATTRIBUTE_COUNT_LIMIT, OTEL_MODULE_NAME
+from atla_insights.id_generator import NoSeedIdGenerator
 from atla_insights.metadata import set_metadata
 from atla_insights.span_processors import (
     AtlaRootSpanProcessor,
@@ -72,6 +73,8 @@ class AtlaInsights:
             span_processors.append(get_atla_console_span_processor())
 
         self.tracer_provider = self._setup_tracer_provider()
+        self.tracer_provider.id_generator = NoSeedIdGenerator()
+
         self.tracer = self.tracer_provider.get_tracer(OTEL_MODULE_NAME)
 
         for processor in span_processors:

--- a/tests/test_id_generator.py
+++ b/tests/test_id_generator.py
@@ -1,0 +1,40 @@
+"""Test custom ID generator."""
+
+import random
+
+from tests._otel import BaseLocalOtel
+
+
+class TestIdGenerator(BaseLocalOtel):
+    """Test custom ID generator."""
+
+    def test_instrumentation_id_conflicts(self) -> None:
+        """Test that the id conflicts are handled correctly."""
+        from atla_insights import instrument
+
+        _SEED = 10
+        random.seed(_SEED)
+
+        @instrument("some_func")
+        def test_function():
+            return "test result"
+
+        test_function()
+
+        random.seed(_SEED)
+
+        test_function()
+
+        spans = self.get_finished_spans()
+
+        assert len(spans) == 2
+        [span_1, span_2] = spans
+
+        context_1 = span_1.get_span_context()
+        context_2 = span_2.get_span_context()
+
+        assert context_1 is not None
+        assert context_2 is not None
+
+        assert context_1.trace_id != context_2.trace_id
+        assert context_1.span_id != context_2.span_id


### PR DESCRIPTION
This PR implements a custom OpenTelemetry ID generator.

Up to this point, we have always either used OpenTelemetry's default ID generator or inherited the ID generator from the tracer provider in any existing OTEL setup.

However, the default ID generator uses Python's built-in `random` module for RNG which can be influenced by any random seeds set in a user's application.
In these cases, you would end up with duplicate span & trace IDs if you executed the application more than once (or reset the seed in some other way), which is undesirable.
Therefore, we _always_ (regardless of whether there is a pre-existing `TracerProvider`) enforce our own, custom, ID generator which uses a `random.Random` instance without seed.