### PR TITLE
Persist metadata dict across contexts

### DIFF
--- a/src/atla_insights/main.py
+++ b/src/atla_insights/main.py
@@ -15,7 +15,7 @@ from opentelemetry.trace import Tracer, set_tracer_provider
 
 from atla_insights.constants import DEFAULT_OTEL_ATTRIBUTE_COUNT_LIMIT, OTEL_MODULE_NAME
 from atla_insights.id_generator import NoSeedIdGenerator
-from atla_insights.metadata import set_metadata
+from atla_insights.metadata import set_global_metadata
 from atla_insights.sampling import TRACE_SAMPLING_TYPE, add_sampling_to_tracer_provider
 from atla_insights.span_processors import add_span_processors_to_tracer_provider
 from atla_insights.utils import maybe_get_existing_tracer_provider
@@ -83,7 +83,7 @@ class AtlaInsights:
             Defaults to `True`.
         """
         if metadata is not None:
-            set_metadata(metadata)
+            set_global_metadata(metadata)
 
         self.tracer_provider = self._setup_tracer_provider()
 

--- a/src/atla_insights/metadata.py
+++ b/src/atla_insights/metadata.py
@@ -85,6 +85,8 @@ def set_global_metadata(metadata: dict[str, str]) -> None:
 
     :param metadata (dict[str, str]): The global metadata.
     """
+    metadata = validate_metadata(metadata)
+
     global _GLOBAL_METADATA
     _GLOBAL_METADATA = metadata
 

--- a/src/atla_insights/metadata.py
+++ b/src/atla_insights/metadata.py
@@ -16,6 +16,8 @@ from atla_insights.context import metadata_var, root_span_var
 
 logger = logging.getLogger(OTEL_MODULE_NAME)
 
+_GLOBAL_METADATA: Optional[dict[str, str]] = None
+
 
 def _truncate_value(value: str, max_chars: int) -> str:
     """Truncate a value to a maximum number of characters.
@@ -75,7 +77,16 @@ def get_metadata() -> Optional[dict[str, str]]:
 
     :return (Optional[dict[str, str]]): The metadata for the current trace.
     """
-    return metadata_var.get()
+    return metadata_var.get() or _GLOBAL_METADATA
+
+
+def set_global_metadata(metadata: dict[str, str]) -> None:
+    """Set the global metadata.
+
+    :param metadata (dict[str, str]): The global metadata.
+    """
+    global _GLOBAL_METADATA
+    _GLOBAL_METADATA = metadata
 
 
 def set_metadata(metadata: dict[str, str]) -> None:

--- a/src/atla_insights/span_processors.py
+++ b/src/atla_insights/span_processors.py
@@ -10,7 +10,8 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcess
 
 from atla_insights.console_span_exporter import ConsoleSpanExporter
 from atla_insights.constants import METADATA_MARK, OTEL_TRACES_ENDPOINT, SUCCESS_MARK
-from atla_insights.context import metadata_var, root_span_var
+from atla_insights.context import root_span_var
+from atla_insights.metadata import get_metadata
 
 
 class AtlaRootSpanProcessor(SpanProcessor):
@@ -24,7 +25,7 @@ class AtlaRootSpanProcessor(SpanProcessor):
         root_span_var.set(span)
         span.set_attribute(SUCCESS_MARK, -1)
 
-        if metadata := metadata_var.get():
+        if metadata := get_metadata():
             span.set_attribute(METADATA_MARK, json.dumps(metadata))
 
     def on_end(self, span: ReadableSpan) -> None:


### PR DESCRIPTION
We used to set global metadata by assigning a validated value to a ContextVar
This means that this global setting will be "lost" when a new context starts
Instead, we now assign global metadata to a global variable that the metadata getter (across contexts) defaults to