### PR TITLE
Feature/google genai deprecated support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,4 +177,5 @@ cython_debug/
 .pypirc
 
 # Misc
+.DS_Store
 tmp/

--- a/examples/llm_providers/instrument_deprecated_google_generativeai.py
+++ b/examples/llm_providers/instrument_deprecated_google_generativeai.py
@@ -1,0 +1,36 @@
+"""Instrument the deprecated Google GenerativeAI client."""
+
+import os
+
+from google.generativeai.generative_models import GenerativeModel
+
+from atla_insights import configure, instrument
+from atla_insights.llm_providers import instrument_google_generativeai
+
+
+@instrument("My GenAI application")
+def my_app() -> None:
+    """My application."""
+    client = GenerativeModel(model_name="gemini-2.0-flash")
+    result = client.generate_content(
+        contents="Explain how AI works in a few words",
+        stream=True,
+    )
+    for chunk in result:
+        print(chunk)
+
+
+def main() -> None:
+    """Main function."""
+    # Configure the client
+    configure(token=os.environ["ATLA_INSIGHTS_TOKEN"])
+
+    # Instrument the deprecated Google GenerativeAI library
+    instrument_google_generativeai()
+
+    # Calling the instrumented function will create spans behind the scenes
+    my_app()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "atla-insights"
-version = "0.0.4"
+version = "0.0.5"
 description = "Atla is a platform for monitoring and improving AI agents."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -43,7 +43,7 @@ anthropic = [
     "openinference-instrumentation-anthropic>=0.1.18",
 ]
 all = [
-    "atla-insights[agno,anthropic,crewai,google-genai,langchain,litellm,mcp,openai,openai-agents,smolagents]",
+    "atla-insights[agno,anthropic,crewai,google-genai,google-generativeai,langchain,litellm,mcp,openai,openai-agents,smolagents]",
 ]
 ci = [
     "mypy>=1.15.0",
@@ -59,6 +59,10 @@ crewai = [
 ]
 google-genai = [
     "google-genai>=1.19.0",
+    "openinference-instrumentation-google-genai>=0.1.2",
+]
+google-generativeai = [
+    "google-generativeai>=0.7.0",
     "openinference-instrumentation-google-genai>=0.1.2",
 ]
 langchain = [

--- a/src/atla_insights/llm_providers/__init__.py
+++ b/src/atla_insights/llm_providers/__init__.py
@@ -8,16 +8,22 @@ from atla_insights.llm_providers.google_genai import (
     instrument_google_genai,
     uninstrument_google_genai,
 )
+from atla_insights.llm_providers.google_generativeai import (
+    instrument_google_generativeai,
+    uninstrument_google_generativeai,
+)
 from atla_insights.llm_providers.litellm import instrument_litellm, uninstrument_litellm
 from atla_insights.llm_providers.openai import instrument_openai, uninstrument_openai
 
 __all__ = [
     "instrument_anthropic",
     "instrument_google_genai",
+    "instrument_google_generativeai",
     "instrument_litellm",
     "instrument_openai",
     "uninstrument_anthropic",
     "uninstrument_google_genai",
+    "uninstrument_google_generativeai",
     "uninstrument_litellm",
     "uninstrument_openai",
 ]

--- a/src/atla_insights/llm_providers/google_generativeai.py
+++ b/src/atla_insights/llm_providers/google_generativeai.py
@@ -1,0 +1,50 @@
+"""Google Generative AI LLM provider instrumentation."""
+
+from typing import ContextManager
+
+from atla_insights.main import ATLA_INSTANCE
+
+
+def instrument_google_generativeai() -> ContextManager[None]:
+    """Instrument the Google Generative AI LLM provider.
+
+    Note that the `google-generativeai` package has been deprecated in favor of
+    `google-genai`, and will reach EOL on September 30, 2025.
+
+    This instrumentation is only provided for backwards compatibility, and is **not** the
+    intended way to instrument Google's Generative AI services.
+
+    Please use `instrument_google_genai` instead.
+
+    This function creates a context manager that instruments the Google GenerativeAI LLM
+    provider, within its context.
+
+    ```py
+    from atla_insights import instrument_google_generativeai
+
+    with instrument_google_generativeai():
+        # My Google Generative AI code here
+    ```
+
+    :return (ContextManager[None]): A context manager that instruments
+        Google Generative AI.
+    """
+    from atla_insights.llm_providers.instrumentors.google_generativeai import (
+        GoogleGenerativeAIInstrumentor,
+    )
+
+    google_generativeai_instrumentor = GoogleGenerativeAIInstrumentor()
+
+    return ATLA_INSTANCE.instrument_service(
+        service=GoogleGenerativeAIInstrumentor.name,
+        instrumentors=[google_generativeai_instrumentor],
+    )
+
+
+def uninstrument_google_generativeai() -> None:
+    """Uninstrument the Google Generative AI LLM provider."""
+    from atla_insights.llm_providers.instrumentors.google_generativeai import (
+        GoogleGenerativeAIInstrumentor,
+    )
+
+    return ATLA_INSTANCE.uninstrument_service(GoogleGenerativeAIInstrumentor.name)

--- a/src/atla_insights/llm_providers/instrumentors/google_genai.py
+++ b/src/atla_insights/llm_providers/instrumentors/google_genai.py
@@ -45,7 +45,11 @@ def _parse_function_call(
             function_id,
         )
 
-    function_args_json = json.dumps(getattr(function_call, "args", {}))
+    function_args_json = "{}"
+    if function_args := getattr(function_call, "args", None):
+        if isinstance(function_args, Mapping):
+            function_args = dict(function_args)
+        function_args_json = json.dumps(function_args)
 
     yield (
         ".".join(

--- a/src/atla_insights/llm_providers/instrumentors/google_generativeai.py
+++ b/src/atla_insights/llm_providers/instrumentors/google_generativeai.py
@@ -1,0 +1,284 @@
+"""Google Generative AI instrumentation."""
+
+import json
+from typing import (
+    Any,
+    AsyncIterator,
+    Callable,
+    Collection,
+    Iterable,
+    Iterator,
+    Mapping,
+    Tuple,
+)
+
+import opentelemetry.trace as trace_api
+from openai.types.chat import ChatCompletionToolParam
+from openai.types.shared_params.function_definition import FunctionDefinition
+from openinference.instrumentation import OITracer, TraceConfig
+from openinference.semconv.trace import (
+    SpanAttributes,
+    ToolAttributes,
+)
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor  # type: ignore
+from opentelemetry.trace import get_tracer, get_tracer_provider
+from opentelemetry.util.types import AttributeValue
+from wrapt import wrap_function_wrapper
+
+try:
+    from openinference.instrumentation.google_genai._stream import _Stream
+    from openinference.instrumentation.google_genai._wrappers import (
+        _AsyncGenerateContentStream,
+        _AsyncGenerateContentWrapper,
+        _SyncGenerateContent,
+        _SyncGenerateContentStream,
+    )
+
+    from atla_insights.llm_providers.instrumentors.google_genai import (
+        _get_tool_calls_from_content_parts,
+    )
+except ImportError as e:
+    raise ImportError(
+        "Google Generative AI instrumentation needs to be installed. "
+        'Please install it via `pip install "atla-insights[google-genai]"`.'
+    ) from e
+
+
+def iter_stream(stream: _Stream) -> Iterator[Any]:
+    """Iterate over a stream and finish the tracing."""
+    try:
+        for item in stream.__wrapped__:
+            stream._response_accumulator._is_null = False
+            stream._response_accumulator._values += item.to_dict()
+            yield item
+    except Exception as exception:
+        status = trace_api.Status(
+            status_code=trace_api.StatusCode.ERROR,
+            description=f"{type(exception).__name__}: {exception}",
+        )
+        stream._with_span.record_exception(exception)
+        stream._finish_tracing(status=status)
+        raise
+
+    status = trace_api.Status(
+        status_code=trace_api.StatusCode.OK,
+    )
+    stream._finish_tracing(status=status)
+
+
+async def aiter_stream(stream: _Stream) -> AsyncIterator[Any]:
+    """Iterate over a stream and finish the tracing."""
+    try:
+        async for item in stream.__wrapped__:
+            stream._response_accumulator._is_null = False
+            stream._response_accumulator._values += item.to_dict()
+            yield item
+    except Exception as exception:
+        status = trace_api.Status(
+            status_code=trace_api.StatusCode.ERROR,
+            description=f"{type(exception).__name__}: {exception}",
+        )
+        stream._with_span.record_exception(exception)
+        stream._finish_tracing(status=status)
+        raise
+
+    status = trace_api.Status(
+        status_code=trace_api.StatusCode.OK,
+    )
+    stream._finish_tracing(status=status)
+
+
+def _parse_function_declaration(function_declaration: object) -> str:
+    """Parse a function declaration and return the attribute JSON schema value."""
+    name = getattr(function_declaration, "name", "")
+    description = getattr(function_declaration, "description", "")
+
+    parameters = {}
+    if function_parameters := getattr(function_declaration, "parameters", None):
+        if json_schema := getattr(function_parameters, "json_schema", None):
+            parameters = json_schema.model_dump(mode="json", exclude_none=True)
+
+    tool_schema = ChatCompletionToolParam(
+        type="function",
+        function=FunctionDefinition(
+            name=name,
+            description=description,
+            parameters=parameters,
+            strict=None,
+        ),
+    )
+    tool_schema_json = json.dumps(tool_schema)
+    return tool_schema_json
+
+
+def _get_tools_from_request(
+    request_parameters: Mapping[str, Any],
+) -> Iterator[Tuple[str, AttributeValue]]:
+    """Get the tools from the request parameters."""
+    tools = request_parameters.get("tools", None)
+    if not tools:
+        return
+
+    tool_idx = 0
+    for tool in tools:
+        if not getattr(tool, "function_declarations", None):
+            continue
+
+        function_declarations = tool.function_declarations
+
+        if not isinstance(function_declarations, Iterable):
+            continue
+
+        for function_declaration in function_declarations:
+            tool_attr_name = ".".join(
+                [
+                    SpanAttributes.LLM_TOOLS,
+                    str(tool_idx),
+                    ToolAttributes.TOOL_JSON_SCHEMA,
+                ]
+            )
+            yield (
+                tool_attr_name,
+                _parse_function_declaration(
+                    function_declaration=function_declaration,
+                ),
+            )
+
+            # Each function declaration is seen as a separate tool.
+            tool_idx += 1
+
+
+def _get_extra_attributes_from_request(
+    wrapped: Callable[..., Any],
+    instance: Any,
+    args: Tuple[Any, ...],
+    kwargs: Mapping[str, Any],
+) -> Iterator[Tuple[str, AttributeValue]]:
+    yield from wrapped(*args, **kwargs)
+    yield from _get_tools_from_request(*args)
+
+
+def _get_attributes_from_content_parts(
+    wrapped: Callable[..., Any],
+    instance: Any,
+    args: Tuple[Any, ...],
+    kwargs: Mapping[str, Any],
+) -> Iterator[Tuple[str, AttributeValue]]:
+    yield from wrapped(*args, **kwargs)
+    yield from _get_tool_calls_from_content_parts(*args)
+
+
+class _GenerateContent:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        wrap_function_wrapper(
+            module="openinference.instrumentation.google_genai._request_attributes_extractor",
+            name="_RequestAttributesExtractor.get_extra_attributes_from_request",
+            wrapper=_get_extra_attributes_from_request,
+        )
+        self.generate_content = _SyncGenerateContent(*args, **kwargs)
+
+        wrap_function_wrapper(
+            module="openinference.instrumentation.google_genai._response_attributes_extractor",
+            name="_ResponseAttributesExtractor._get_attributes_from_content_parts",
+            wrapper=_get_attributes_from_content_parts,
+        )
+        self.generate_content_stream = _SyncGenerateContentStream(*args, **kwargs)
+
+    def __call__(
+        self,
+        wrapped: Callable[..., Any],
+        instance: Any,
+        args: Tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> Any:
+        if kwargs.get("stream"):
+            stream = self.generate_content_stream(wrapped, instance, args, kwargs)
+            if isinstance(stream, _Stream):
+                return iter_stream(stream)
+            else:
+                return stream
+        else:
+            return self.generate_content(wrapped, instance, args, kwargs)
+
+
+class _AsyncGenerateContent:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.generate_content = _AsyncGenerateContentWrapper(*args, **kwargs)
+        self.generate_content_stream = _AsyncGenerateContentStream(*args, **kwargs)
+
+    async def __call__(
+        self,
+        wrapped: Callable[..., Any],
+        instance: Any,
+        args: Tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> AsyncIterator[Any]:
+        if kwargs.get("stream"):
+            stream = await self.generate_content_stream(wrapped, instance, args, kwargs)
+            if isinstance(stream, _Stream):
+                return aiter_stream(stream)
+            else:
+                return stream
+        else:
+            return await self.generate_content(wrapped, instance, args, kwargs)
+
+
+class GoogleGenerativeAIInstrumentor(BaseInstrumentor):
+    """An instrumentor for `google-generativeai`."""
+
+    name = "google-generativeai"
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        """The instrumentation dependencies for `google-generativeai`."""
+        return ("google-generativeai",)
+
+    def _instrument(self, **kwargs: Any) -> None:
+        if not (tracer_provider := kwargs.get("tracer_provider")):
+            tracer_provider = get_tracer_provider()
+        if not (config := kwargs.get("config")):
+            config = TraceConfig()
+        else:
+            assert isinstance(config, TraceConfig)
+        self._tracer = OITracer(
+            get_tracer(
+                instrumenting_module_name="openinference.instrumentation.google_genai",
+                instrumenting_library_version="0.8.5",
+                tracer_provider=tracer_provider,
+            ),
+            config=config,
+        )
+
+        try:
+            from google.generativeai.generative_models import GenerativeModel
+        except ImportError as err:
+            raise Exception(
+                "Could not import google-generativeai. "
+                "Please install with `pip install google-generativeai`."
+            ) from err
+
+        self._original_generate_content = GenerativeModel.generate_content
+        wrap_function_wrapper(
+            module="google.generativeai.generative_models",
+            name="GenerativeModel.generate_content",
+            wrapper=_GenerateContent(tracer=self._tracer),
+        )
+
+        self._original_async_generate_content = GenerativeModel.generate_content_async
+        wrap_function_wrapper(
+            module="google.generativeai.generative_models",
+            name="GenerativeModel.generate_content_async",
+            wrapper=_AsyncGenerateContent(tracer=self._tracer),
+        )
+
+    def _uninstrument(self, **kwargs: Any) -> None:
+        from google.generativeai.generative_models import GenerativeModel
+
+        if self._original_generate_content is not None:
+            GenerativeModel.generate_content = (  # type: ignore[method-assign]
+                self._original_generate_content
+            )
+
+        if self._original_async_generate_content is not None:
+            GenerativeModel.generate_content_async = (  # type: ignore[method-assign]
+                self._original_async_generate_content
+            )

--- a/src/atla_insights/llm_providers/instrumentors/google_generativeai.py
+++ b/src/atla_insights/llm_providers/instrumentors/google_generativeai.py
@@ -40,7 +40,7 @@ try:
 except ImportError as e:
     raise ImportError(
         "Google Generative AI instrumentation needs to be installed. "
-        'Please install it via `pip install "atla-insights[google-genai]"`.'
+        'Please install it via `pip install "atla-insights[google-generativeai]"`.'
     ) from e
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -209,7 +209,7 @@ wheels = [
 
 [[package]]
 name = "atla-insights"
-version = "0.0.4"
+version = "0.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "openai" },
@@ -234,6 +234,7 @@ all = [
     { name = "anthropic" },
     { name = "crewai" },
     { name = "google-genai" },
+    { name = "google-generativeai" },
     { name = "langchain" },
     { name = "langchain-openai" },
     { name = "langgraph" },
@@ -271,6 +272,10 @@ google-genai = [
     { name = "google-genai" },
     { name = "openinference-instrumentation-google-genai" },
 ]
+google-generativeai = [
+    { name = "google-generativeai" },
+    { name = "openinference-instrumentation-google-genai" },
+]
 langchain = [
     { name = "langchain" },
     { name = "langchain-openai" },
@@ -306,9 +311,10 @@ dev = [
 requires-dist = [
     { name = "agno", marker = "extra == 'agno'", specifier = ">=1.5.0" },
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.52.1" },
-    { name = "atla-insights", extras = ["agno", "anthropic", "crewai", "google-genai", "langchain", "litellm", "mcp", "openai", "openai-agents", "smolagents"], marker = "extra == 'all'" },
+    { name = "atla-insights", extras = ["agno", "anthropic", "crewai", "google-genai", "google-generativeai", "langchain", "litellm", "mcp", "openai", "openai-agents", "smolagents"], marker = "extra == 'all'" },
     { name = "crewai", marker = "extra == 'crewai'", specifier = ">=0.130.0" },
     { name = "google-genai", marker = "extra == 'google-genai'", specifier = ">=1.19.0" },
+    { name = "google-generativeai", marker = "extra == 'google-generativeai'", specifier = ">=0.7.0" },
     { name = "langchain", marker = "extra == 'langchain'", specifier = ">=0.3.18" },
     { name = "langchain-openai", marker = "extra == 'langchain'", specifier = ">=0.3.4" },
     { name = "langgraph", marker = "extra == 'langchain'", specifier = ">=0.3.20" },
@@ -323,6 +329,7 @@ requires-dist = [
     { name = "openinference-instrumentation-anthropic", marker = "extra == 'anthropic'", specifier = ">=0.1.18" },
     { name = "openinference-instrumentation-crewai", marker = "extra == 'crewai'", specifier = ">=0.1.10" },
     { name = "openinference-instrumentation-google-genai", marker = "extra == 'google-genai'", specifier = ">=0.1.2" },
+    { name = "openinference-instrumentation-google-genai", marker = "extra == 'google-generativeai'", specifier = ">=0.1.2" },
     { name = "openinference-instrumentation-langchain", marker = "extra == 'langchain'", specifier = ">=0.1.43" },
     { name = "openinference-instrumentation-mcp", marker = "extra == 'mcp'", specifier = ">=1.3.0" },
     { name = "openinference-instrumentation-openai", marker = "extra == 'openai'", specifier = ">=0.1.30" },
@@ -343,7 +350,7 @@ requires-dist = [
     { name = "smolagents", marker = "extra == 'smolagents'", specifier = ">=1.17.0" },
     { name = "wrapt", specifier = ">=1.17.2" },
 ]
-provides-extras = ["agno", "anthropic", "all", "ci", "crewai", "google-genai", "langchain", "litellm", "mcp", "openai", "openai-agents", "smolagents"]
+provides-extras = ["agno", "anthropic", "all", "ci", "crewai", "google-genai", "google-generativeai", "langchain", "litellm", "mcp", "openai", "openai-agents", "smolagents"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "atla-insights", extras = ["all", "ci"] }]
@@ -1025,6 +1032,59 @@ wheels = [
 ]
 
 [[package]]
+name = "google-ai-generativelanguage"
+version = "0.6.15"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/11/d1/48fe5d7a43d278e9f6b5ada810b0a3530bbeac7ed7fcbcd366f932f05316/google_ai_generativelanguage-0.6.15.tar.gz", hash = "sha256:8f6d9dc4c12b065fe2d0289026171acea5183ebf2d0b11cefe12f3821e159ec3", size = 1375443, upload-time = "2025-01-13T21:50:47.459Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/a3/67b8a6ff5001a1d8864922f2d6488dc2a14367ceb651bc3f09a947f2f306/google_ai_generativelanguage-0.6.15-py3-none-any.whl", hash = "sha256:5a03ef86377aa184ffef3662ca28f19eeee158733e45d7947982eb953c6ebb6c", size = 1327356, upload-time = "2025-01-13T21:50:44.174Z" },
+]
+
+[[package]]
+name = "google-api-core"
+version = "2.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/21/e9d043e88222317afdbdb567165fdbc3b0aad90064c7e0c9eb0ad9955ad8/google_api_core-2.25.1.tar.gz", hash = "sha256:d2aaa0b13c78c61cb3f4282c464c046e45fbd75755683c9c525e6e8f7ed0a5e8", size = 165443, upload-time = "2025-06-12T20:52:20.439Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/4b/ead00905132820b623732b175d66354e9d3e69fcf2a5dcdab780664e7896/google_api_core-2.25.1-py3-none-any.whl", hash = "sha256:8a2a56c1fef82987a524371f99f3bd0143702fecc670c72e600c1cda6bf8dbb7", size = 160807, upload-time = "2025-06-12T20:52:19.334Z" },
+]
+
+[package.optional-dependencies]
+grpc = [
+    { name = "grpcio" },
+    { name = "grpcio-status" },
+]
+
+[[package]]
+name = "google-api-python-client"
+version = "2.176.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-auth-httplib2" },
+    { name = "httplib2" },
+    { name = "uritemplate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/38/daf70faf6d05556d382bac640bc6765f09fcfb9dfb51ac4a595d3453a2a9/google_api_python_client-2.176.0.tar.gz", hash = "sha256:2b451cdd7fd10faeb5dd20f7d992f185e1e8f4124c35f2cdcc77c843139a4cf1", size = 13154773, upload-time = "2025-07-08T18:07:10.354Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/2c/758f415a19a12c3c6d06902794b0dd4c521d912a59b98ab752bba48812df/google_api_python_client-2.176.0-py3-none-any.whl", hash = "sha256:e22239797f1d085341e12cd924591fc65c56d08e0af02549d7606092e6296510", size = 13678445, upload-time = "2025-07-08T18:07:07.799Z" },
+]
+
+[[package]]
 name = "google-auth"
 version = "2.40.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1036,6 +1096,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9e/9b/e92ef23b84fa10a64ce4831390b7a4c2e53c0132568d99d4ae61d04c8855/google_auth-2.40.3.tar.gz", hash = "sha256:500c3a29adedeb36ea9cf24b8d10858e152f2412e3ca37829b3fa18e33d63b77", size = 281029, upload-time = "2025-06-04T18:04:57.577Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/63/b19553b658a1692443c62bd07e5868adaa0ad746a0751ba62c59568cd45b/google_auth-2.40.3-py2.py3-none-any.whl", hash = "sha256:1370d4593e86213563547f97a92752fc658456fe4514c809544f330fed45a7ca", size = 216137, upload-time = "2025-06-04T18:04:55.573Z" },
+]
+
+[[package]]
+name = "google-auth-httplib2"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "httplib2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/be/217a598a818567b28e859ff087f347475c807a5649296fb5a817c58dacef/google-auth-httplib2-0.2.0.tar.gz", hash = "sha256:38aa7badf48f974f1eb9861794e9c0cb2a0511a4ec0679b1f886d108f5640e05", size = 10842, upload-time = "2023-12-12T17:40:30.722Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/8a/fe34d2f3f9470a27b01c9e76226965863f153d5fbe276f83608562e49c04/google_auth_httplib2-0.2.0-py2.py3-none-any.whl", hash = "sha256:b65a0a2123300dd71281a7bf6e64d65a0759287df52729bdd1ae2e47dc311a3d", size = 9253, upload-time = "2023-12-12T17:40:13.055Z" },
 ]
 
 [[package]]
@@ -1055,6 +1128,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/49/8a/4a628e2e918f8c4a48ea778b68395b97b05b6873c6e528e78ccfb02a2c8d/google_genai-1.21.1.tar.gz", hash = "sha256:5412fde7f0b39574a4670a9a25e398824a12b3cddd632fdff66d1b9bcfdbfcb4", size = 205636, upload-time = "2025-06-19T14:09:20.466Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/92/5c/659c2b992d631a873ae8fed612ce92af423fdc5f7d541dec7ce8f4b1789e/google_genai-1.21.1-py3-none-any.whl", hash = "sha256:fa6fa5311f9a757ce65cd528a938a0f309bb3032516015bf5b3022e63b2fc46b", size = 206388, upload-time = "2025-06-19T14:09:19.016Z" },
+]
+
+[[package]]
+name = "google-generativeai"
+version = "0.8.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-ai-generativelanguage" },
+    { name = "google-api-core" },
+    { name = "google-api-python-client" },
+    { name = "google-auth" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/40/c42ff9ded9f09ec9392879a8e6538a00b2dc185e834a3392917626255419/google_generativeai-0.8.5-py3-none-any.whl", hash = "sha256:22b420817fb263f8ed520b33285f45976d5b21e904da32b80d4fd20c055123a2", size = 155427, upload-time = "2025-04-17T00:40:00.67Z" },
 ]
 
 [[package]]
@@ -1181,6 +1272,20 @@ wheels = [
 ]
 
 [[package]]
+name = "grpcio-status"
+version = "1.71.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/d1/b6e9877fedae3add1afdeae1f89d1927d296da9cf977eca0eb08fb8a460e/grpcio_status-1.71.2.tar.gz", hash = "sha256:c7a97e176df71cdc2c179cd1847d7fc86cca5832ad12e9798d7fed6b7a1aab50", size = 13677, upload-time = "2025-06-28T04:24:05.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/58/317b0134129b556a93a3b0afe00ee675b5657f0155509e22fcb853bafe2d/grpcio_status-1.71.2-py3-none-any.whl", hash = "sha256:803c98cb6a8b7dc6dbb785b1111aed739f241ab5e9da0bba96888aa74704cfd3", size = 14424, upload-time = "2025-06-28T04:23:42.136Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1215,6 +1320,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httplib2"
+version = "0.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/ad/2371116b22d616c194aa25ec410c9c6c37f23599dcd590502b74db197584/httplib2-0.22.0.tar.gz", hash = "sha256:d7a10bc5ef5ab08322488bde8c726eeee5c8618723fdb399597ec58f3d82df81", size = 351116, upload-time = "2023-03-21T22:29:37.214Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/6c/d2fbdaaa5959339d53ba38e94c123e4e84b8fbc4b84beb0e70d7c1608486/httplib2-0.22.0-py3-none-any.whl", hash = "sha256:14ae0a53c1ba8f3d37e9e27cf37eabb0fb9980f435ba405d546948b009dd64dc", size = 96854, upload-time = "2023-03-21T22:29:35.683Z" },
 ]
 
 [[package]]
@@ -2902,11 +3019,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "24.2"
+version = "23.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950, upload-time = "2024-11-08T09:47:47.202Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/2b/9b9c33ffed44ee921d0967086d653047286054117d584f1b1a7c22ceaf7b/packaging-23.2.tar.gz", hash = "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5", size = 146714, upload-time = "2023-10-01T13:50:05.279Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451, upload-time = "2024-11-08T09:47:44.722Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/1a/610693ac4ee14fcdf2d9bf3c493370e4f2ef7ae2e19217d7a237ff42367d/packaging-23.2-py3-none-any.whl", hash = "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7", size = 53011, upload-time = "2023-10-01T13:50:03.745Z" },
 ]
 
 [[package]]
@@ -3201,6 +3318,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/4c/b0fe775a2bdd01e176b14b574be679d84fc83958335790f7c9a686c1f468/propcache-0.3.2-cp313-cp313t-win32.whl", hash = "sha256:f86e5d7cd03afb3a1db8e9f9f6eff15794e79e791350ac48a8c924e6f439f394", size = 41175, upload-time = "2025-06-09T22:55:38.436Z" },
     { url = "https://files.pythonhosted.org/packages/a4/ff/47f08595e3d9b5e149c150f88d9714574f1a7cbd89fe2817158a952674bf/propcache-0.3.2-cp313-cp313t-win_amd64.whl", hash = "sha256:9704bedf6e7cbe3c65eca4379a9b53ee6a83749f047808cbb5044d40d7d72198", size = 44857, upload-time = "2025-06-09T22:55:39.687Z" },
     { url = "https://files.pythonhosted.org/packages/cc/35/cc0aaecf278bb4575b8555f2b137de5ab821595ddae9da9d3cd1da4072c7/propcache-0.3.2-py3-none-any.whl", hash = "sha256:98f1ec44fb675f5052cccc8e609c46ed23a35a1cfd18545ad4e29002d858a43f", size = 12663, upload-time = "2025-06-09T22:56:04.484Z" },
+]
+
+[[package]]
+name = "proto-plus"
+version = "1.26.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/ac/87285f15f7cce6d4a008f33f1757fb5a13611ea8914eb58c3d0d26243468/proto_plus-1.26.1.tar.gz", hash = "sha256:21a515a4c4c0088a773899e23c7bbade3d18f9c66c73edd4c7ee3816bc96a012", size = 56142, upload-time = "2025-03-10T15:54:38.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/6d/280c4c2ce28b1593a19ad5239c8b826871fc6ec275c21afc8e1820108039/proto_plus-1.26.1-py3-none-any.whl", hash = "sha256:13285478c2dcf2abb829db158e1047e2f1e8d63a077d94263c2b88b043c75a66", size = 50163, upload-time = "2025-03-10T15:54:37.335Z" },
 ]
 
 [[package]]
@@ -3515,6 +3644,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1a/0a/c06b542ac108bfc73200677309cd9188a3a01b127a63f20cadc18d873d88/pymdown_extensions-10.16.tar.gz", hash = "sha256:71dac4fca63fabeffd3eb9038b756161a33ec6e8d230853d3cecf562155ab3de", size = 853197, upload-time = "2025-06-21T17:56:36.974Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/98/d4/10bb14004d3c792811e05e21b5e5dcae805aacb739bd12a0540967b99592/pymdown_extensions-10.16-py3-none-any.whl", hash = "sha256:f5dd064a4db588cb2d95229fc4ee63a1b16cc8b4d0e6145c0899ed8723da1df2", size = 266143, upload-time = "2025-06-21T17:56:35.356Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/22/f1129e69d94ffff626bdb5c835506b3a5b4f3d070f17ea295e12c2c6f60f/pyparsing-3.2.3.tar.gz", hash = "sha256:b9c13f1ab8b3b542f72e28f634bad4de758ab3ce4546e4301970ad6fa77c38be", size = 1088608, upload-time = "2025-03-25T05:01:28.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/e7/df2285f3d08fee213f2d041540fa4fc9ca6c2d44cf36d3a035bf2a8d2bcc/pyparsing-3.2.3-py3-none-any.whl", hash = "sha256:a749938e02d6fd0b59b356ca504a24982314bb090c383e3cf201c95ef7e2bfcf", size = 111120, upload-time = "2025-03-25T05:01:24.908Z" },
 ]
 
 [[package]]
@@ -4312,6 +4450,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28", size = 75726, upload-time = "2025-05-21T18:55:23.885Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51", size = 14552, upload-time = "2025-05-21T18:55:22.152Z" },
+]
+
+[[package]]
+name = "uritemplate"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/60/f174043244c5306c9988380d2cb10009f91563fc4b31293d27e17201af56/uritemplate-4.2.0.tar.gz", hash = "sha256:480c2ed180878955863323eea31b0ede668795de182617fef9c6ca09e6ec9d0e", size = 33267, upload-time = "2025-06-02T15:12:06.318Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/99/3ae339466c9183ea5b8ae87b34c0b897eda475d2aec2307cae60e5cd4f29/uritemplate-4.2.0-py3-none-any.whl", hash = "sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686", size = 11488, upload-time = "2025-06-02T15:12:03.405Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds instrumentation support for the [`google-generativeai` package](https://github.com/google-gemini/deprecated-generative-ai-python).

The instrumentation is similar to the one for Google's new, unified `google-genai` SDK but accounts for some key differences in the deprecated interface.

⚠️ Considering the `google-genai` VS `google-generativeai` syntax can be confusing for the uninitiated, I decided to **not** expose the `instrument_google_generativeai` at the top level. 
Instead, users of this deprecated functionality have to import it from `from atla_insights.llm_providers import instrument_google_generativeai`.
Similarly, we don't explicitly mention support in our main README.md to avoid confusion / mistakes.
-> The overarching goal is: 
- if a user uses `google-genai`, they can safely use our instrumentation without ever getting exposed to the `google-generativeai` naming.
- if a user uses `google-generativeai`, they can use our instrumentation in a "slightly more advanced way", and are likely aware they are using deprecated functionality.