### PR TITLE
Track SDK version

### DIFF
--- a/src/atla_insights/constants.py
+++ b/src/atla_insights/constants.py
@@ -1,6 +1,9 @@
 """Constants for the atla_insights package."""
 
+import importlib.metadata
 from typing import Literal, Sequence, Union
+
+__version__ = importlib.metadata.version("atla-insights")
 
 DEFAULT_OTEL_ATTRIBUTE_COUNT_LIMIT = 4096
 
@@ -12,6 +15,7 @@ OTEL_NAMESPACE = "atla"
 
 METADATA_MARK = f"{OTEL_NAMESPACE}.metadata"
 SUCCESS_MARK = f"{OTEL_NAMESPACE}.mark.success"
+VERSION_MARK = f"{OTEL_NAMESPACE}.sdk.version"
 
 OTEL_MODULE_NAME = "atla_insights"
 OTEL_TRACES_ENDPOINT = "https://logfire-eu.pydantic.dev/v1/traces"

--- a/src/atla_insights/span_processors.py
+++ b/src/atla_insights/span_processors.py
@@ -9,7 +9,13 @@ from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor, TracerPro
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor
 
 from atla_insights.console_span_exporter import ConsoleSpanExporter
-from atla_insights.constants import METADATA_MARK, OTEL_TRACES_ENDPOINT, SUCCESS_MARK
+from atla_insights.constants import (
+    METADATA_MARK,
+    OTEL_TRACES_ENDPOINT,
+    SUCCESS_MARK,
+    VERSION_MARK,
+    __version__,
+)
 from atla_insights.context import metadata_var, root_span_var
 
 
@@ -18,6 +24,8 @@ class AtlaRootSpanProcessor(SpanProcessor):
 
     def on_start(self, span: Span, parent_context: Optional[Context] = None) -> None:
         """On start span processing."""
+        span.set_attribute(VERSION_MARK, __version__)
+
         if span.parent is not None:
             return
 


### PR DESCRIPTION
Track SDK version in Atla spans as the `atla.sdk.version` attribute.
This will greatly help any future debugging efforts