### PR TITLE
[FIX] Pin google GenerativeAI openinference version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "atla-insights"
-version = "0.0.6"
+version = "0.0.7"
 description = "Atla is a platform for monitoring and improving AI agents."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ google-genai = [
 ]
 google-generativeai = [
     "google-generativeai>=0.7.0",
-    "openinference-instrumentation-google-genai>=0.1.2",
+    "openinference-instrumentation-google-genai==0.1.2",
 ]
 langchain = [
     "langchain>=0.3.18",

--- a/uv.lock
+++ b/uv.lock
@@ -349,7 +349,7 @@ requires-dist = [
     { name = "openinference-instrumentation-bedrock", marker = "extra == 'bedrock'", specifier = ">=0.1.26" },
     { name = "openinference-instrumentation-crewai", marker = "extra == 'crewai'", specifier = ">=0.1.10" },
     { name = "openinference-instrumentation-google-genai", marker = "extra == 'google-genai'", specifier = "==0.1.2" },
-    { name = "openinference-instrumentation-google-genai", marker = "extra == 'google-generativeai'", specifier = ">=0.1.2" },
+    { name = "openinference-instrumentation-google-genai", marker = "extra == 'google-generativeai'", specifier = "==0.1.2" },
     { name = "openinference-instrumentation-langchain", marker = "extra == 'langchain'", specifier = "==0.1.43" },
     { name = "openinference-instrumentation-mcp", marker = "extra == 'mcp'", specifier = ">=1.3.0" },
     { name = "openinference-instrumentation-openai", marker = "extra == 'openai'", specifier = ">=0.1.30" },

--- a/uv.lock
+++ b/uv.lock
@@ -215,7 +215,7 @@ wheels = [
 
 [[package]]
 name = "atla-insights"
-version = "0.0.6"
+version = "0.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "openai" },


### PR DESCRIPTION
Pin `google-generative-ai` openinference version to `v0.1.2`
We noticed a breaking regression in behavior in `v0.1.6` (possibly introduced earlier)