### PR TITLE
[FIX] Pin litellm version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "atla-insights"
-version = "0.0.12"
+version = "0.0.13"
 description = "Atla is a platform for monitoring and improving AI agents."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -215,7 +215,7 @@ wheels = [
 
 [[package]]
 name = "atla-insights"
-version = "0.0.12"
+version = "0.0.13"
 source = { editable = "." }
 dependencies = [
     { name = "openai" },


### PR DESCRIPTION
There is a regression in LiteLLM versions >1.74.0 that causes our litellm callbacks to be flaky
This PR bounds the litellm versions to a (narrow) range we know works fine