### PR TITLE
[Fix] Google generativeai uninstrumentation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "atla-insights"
-version = "0.0.13"
+version = "0.0.14"
 description = "Atla is a platform for monitoring and improving AI agents."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/atla_insights/llm_providers/instrumentors/google_generativeai.py
+++ b/src/atla_insights/llm_providers/instrumentors/google_generativeai.py
@@ -263,14 +263,18 @@ class GoogleGenerativeAIInstrumentor(BaseInstrumentor):
                 "Please install with `pip install google-generativeai`."
             ) from err
 
-        self._original_generate_content = GenerativeModel.generate_content
+        self._original_generate_content = (
+            GenerativeModel.generate_content  # type: ignore[assignment]
+        )
         wrap_function_wrapper(
             module="google.generativeai.generative_models",
             name="GenerativeModel.generate_content",
             wrapper=_GenerateContent(tracer=self._tracer),
         )
 
-        self._original_async_generate_content = GenerativeModel.generate_content_async
+        self._original_async_generate_content = (
+            GenerativeModel.generate_content_async  # type: ignore[assignment]
+        )
         wrap_function_wrapper(
             module="google.generativeai.generative_models",
             name="GenerativeModel.generate_content_async",

--- a/src/atla_insights/llm_providers/instrumentors/google_generativeai.py
+++ b/src/atla_insights/llm_providers/instrumentors/google_generativeai.py
@@ -228,6 +228,13 @@ class GoogleGenerativeAIInstrumentor(BaseInstrumentor):
 
     name = "google-generativeai"
 
+    def __init__(self) -> None:
+        """Initialize the GoogleGenerativeAIInstrumentor."""
+        super().__init__()
+
+        self._original_generate_content = None
+        self._original_async_generate_content = None
+
     def instrumentation_dependencies(self) -> Collection[str]:
         """The instrumentation dependencies for `google-generativeai`."""
         return ("google-generativeai",)

--- a/uv.lock
+++ b/uv.lock
@@ -215,7 +215,7 @@ wheels = [
 
 [[package]]
 name = "atla-insights"
-version = "0.0.13"
+version = "0.0.14"
 source = { editable = "." }
 dependencies = [
     { name = "openai" },


### PR DESCRIPTION
Fix uninstrumentation for the Google GenerativeAI package
-> we potentially access a non-initialized variable when uninstrumenting the `google.generativeai` - which leads to issues in multi-threaded applications