### PR TITLE
[FIX] Claude Code SDK functional usage pattern

### DIFF
--- a/examples/frameworks/instrument_claude_code_sdk.py
+++ b/examples/frameworks/instrument_claude_code_sdk.py
@@ -16,7 +16,6 @@ async def my_app() -> None:
             system_prompt="You are a performance engineer",
             allowed_tools=["Bash", "Read", "WebSearch"],
             max_turns=3,
-            mcp_tools=["mcp__file_system", "mcp__text_editor"],
         )
     ) as client:
         await client.query("Analyze system performance")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "atla-insights"
-version = "0.0.18"
+version = "0.0.19"
 description = "Atla is a platform for monitoring and improving AI agents."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -216,7 +216,7 @@ wheels = [
 
 [[package]]
 name = "atla-insights"
-version = "0.0.18"
+version = "0.0.19"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
This PR adds instrumentation support for Claude Code SDK usage pattern (i.e. using `from claude_code_sdk import query` directly rather than `from claude_code_sdk import ClaudeSDKClient`)
The functional usage patterns only uses the `SubprocessCLITransport` client for gathering CLI output but not for sending the initial request - causing partial data to be sent to the Atla OTEL endpoint