### PR TITLE
support experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ You can retrieve your authentication token from the [Atla Insights platform](htt
 Separate traces between development and production environments:
 
 ```python
+import os
+
+from atla_insights import configure
+
 # Development environment
 configure(token="<TOKEN>", environment="dev")
 
@@ -57,7 +61,7 @@ configure(token="<TOKEN>", environment="dev")
 configure(token="<TOKEN>", environment="prod")
 
 # Via environment variable
-export ATLA_INSIGHTS_ENVIRONMENT=dev
+os.environ["ATLA_INSIGHTS_ENVIRONMENT"] = "dev"
 configure(token="<TOKEN>")  # Uses "dev" from env var
 ```
 
@@ -222,6 +226,17 @@ configure(
     token="<MY_ATLA_INSIGHTS_TOKEN>",
     metadata=metadata,
 )
+```
+
+#### Dynamic metadata
+
+Metadata set with the `configure` function will be attached to all traces. You can also set metadata dynamically during runtime. This is useful, for example, to "tag" specific traces with information that is only available during runtime.
+
+```python
+from atla_insights import set_metadata
+
+# ... within instrumented context ...
+set_metadata({"some_key": "some_value", "other_key": "other_value"})
 ```
 
 ### Tool invocations

--- a/README.md
+++ b/README.md
@@ -371,6 +371,19 @@ def run_my_agent() -> None:
 
 ⚠️ Note that you should use this marking functionality within an instrumented function.
 
+### Running experiments
+
+You can generate runs of your Atla Insights experiments by using the `run_experiment` context manager.
+
+```python
+from atla_insights import run_experiment
+
+with run_experiment(experiment_id="my-experiment-id"):
+    # Your experiment code here
+```
+
+To get started, you'll need to create an experiment in the [Atla Insights platform](https://app.atla-ai.com) and follow the instructions there.
+
 ### Compatibility with existing observability
 
 As `atla_insights` provides its own instrumentation, we should note potential interactions

--- a/examples/experiment.py
+++ b/examples/experiment.py
@@ -1,0 +1,46 @@
+"""Running an experiment example."""
+
+from openai import OpenAI
+
+from atla_insights import (
+    configure,
+    instrument,
+    instrument_openai,
+    run_experiment,
+)
+
+
+@instrument("My GenAI application")
+def my_app(client: OpenAI) -> None:
+    """My application."""
+    _ = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[
+            {
+                "role": "user",
+                "content": "What is 1 + 2? Reply with only the answer, nothing else.",
+            }
+        ],
+    )
+
+
+def main() -> None:
+    """Main function."""
+    # Configure the client
+    configure(token="pylf_v1_eu_GWQ3C6xppx3CWfgvnsTgXmz5TRdPYdTfqHl6dtynlZVv")
+    # configure(token=os.environ["ATLA_INSIGHTS_TOKEN"])
+
+    # Create an OpenAI client
+    client = OpenAI()
+
+    # Instrument the OpenAI client
+    instrument_openai()
+
+    # Run your app in the context of an experiment.
+    # Your traces with be associated with a new run for the experiment.
+    with run_experiment("My experiment"):
+        my_app(client)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/experiment.py
+++ b/examples/experiment.py
@@ -1,5 +1,7 @@
 """Running an experiment example."""
 
+import os
+
 from openai import OpenAI
 
 from atla_insights import (
@@ -26,9 +28,12 @@ def my_app(client: OpenAI) -> None:
 
 def main() -> None:
     """Main function."""
-    # Configure the client
-    configure(token="pylf_v1_eu_GWQ3C6xppx3CWfgvnsTgXmz5TRdPYdTfqHl6dtynlZVv")
-    # configure(token=os.environ["ATLA_INSIGHTS_TOKEN"])
+    # Configure the client. Experiments run in the "dev" environment by default,
+    # but setting this here avoids a warning.
+    configure(
+        token=os.environ["ATLA_INSIGHTS_TOKEN"],
+        environment="dev",
+    )
 
     # Create an OpenAI client
     client = OpenAI()
@@ -38,7 +43,7 @@ def main() -> None:
 
     # Run your app in the context of an experiment.
     # Your traces with be associated with a new run for the experiment.
-    with run_experiment("My experiment"):
+    with run_experiment(experiment_id="123"):
         my_app(client)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
 ]
 dependencies = [
+    "cuid2>=2.0.1",
     "httpx>=0.24.0",
     "openai>=1.77.0",
     "openinference-instrumentation>=0.1.32",
@@ -24,6 +25,7 @@ dependencies = [
     "opentelemetry-exporter-otlp-proto-grpc>=1.32.1",
     "opentelemetry-exporter-otlp-proto-http>=1.32.1",
     "opentelemetry-instrumentation>=0.54b0",
+    "pygit2>=1.16.0",
     "pydantic>=2.11.4",
     "python-dateutil>=2.8.0",
     "rich>=13.9.4",

--- a/src/atla_insights/__init__.py
+++ b/src/atla_insights/__init__.py
@@ -2,6 +2,7 @@
 
 from atla_insights.client import Client
 from atla_insights.custom_metrics import get_custom_metrics, set_custom_metrics
+from atla_insights.experiments import run_experiment
 from atla_insights.frameworks import (
     instrument_agno,
     instrument_baml,
@@ -62,6 +63,7 @@ __all__ = [
     "instrument_smolagents",
     "mark_failure",
     "mark_success",
+    "run_experiment",
     "set_custom_metrics",
     "set_metadata",
     "suppress_instrumentation",

--- a/src/atla_insights/constants.py
+++ b/src/atla_insights/constants.py
@@ -54,6 +54,8 @@ METADATA_MARK = f"{OTEL_NAMESPACE}.metadata"
 SUCCESS_MARK = f"{OTEL_NAMESPACE}.mark.success"
 VERSION_MARK = f"{OTEL_NAMESPACE}.sdk.version"
 
+EXPERIMENT_RUN_NAMESPACE = f"{OTEL_NAMESPACE}.experiment.run"
+
 OTEL_MODULE_NAME = "atla_insights"
 OTEL_TRACES_ENDPOINT = "https://logfire-eu.pydantic.dev/v1/traces"
 

--- a/src/atla_insights/context.py
+++ b/src/atla_insights/context.py
@@ -1,9 +1,12 @@
 """Context variables for the atla_insights package."""
 
 from contextvars import ContextVar
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from opentelemetry.sdk.trace import Span
+
+if TYPE_CHECKING:
+    from atla_insights.experiments import ExperimentRun
 
 metadata_var: ContextVar[Optional[dict[str, str]]] = ContextVar(
     "metadata_var", default=None
@@ -11,4 +14,7 @@ metadata_var: ContextVar[Optional[dict[str, str]]] = ContextVar(
 root_span_var: ContextVar[Optional[Span]] = ContextVar("root_span_var", default=None)
 suppress_instrumentation_var: ContextVar[bool] = ContextVar(
     "suppress_instrumentation", default=False
+)
+experiment_run_var: ContextVar[Optional["ExperimentRun"]] = ContextVar(
+    "experiment_run_var", default=None
 )

--- a/src/atla_insights/experiments.py
+++ b/src/atla_insights/experiments.py
@@ -1,0 +1,61 @@
+"""Experiment support for the atla_insights package."""
+
+from contextlib import contextmanager
+from typing import Generator, Optional, TypedDict
+
+from atla_insights.context import experiment_run_var
+from atla_insights.utils import (
+    generate_cuid,
+    get_git_branch,
+    get_git_commit_hash,
+    get_git_commit_message,
+)
+
+
+class ExperimentRun(TypedDict):
+    """A run of an experiment."""
+
+    id: str
+    experiment_id: str
+
+    description: Optional[str]
+
+    git_branch: Optional[str]
+    git_commit_hash: Optional[str]
+    git_commit_message: Optional[str]
+
+
+@contextmanager
+def run_experiment(
+    experiment_id: str,
+    description: Optional[str] = None,
+) -> Generator[ExperimentRun, None, None]:
+    """Context manager for running experiments with automatic tracking.
+
+    This sets up experiment and experiment run context variables and
+    ensures proper OpenTelemetry attributes are set for tracking.
+
+    Args:
+        experiment_id: ID of the experiment to generate a run for
+        description: Optional description for this experiment run
+
+    Yields:
+        ExperimentRun: The experiment run instance
+    """
+    # Create experiment run object in context
+    experiment_run = ExperimentRun(
+        id=generate_cuid(),
+        experiment_id=experiment_id,
+        description=description,
+        git_branch=get_git_branch(),
+        git_commit_hash=get_git_commit_hash(),
+        git_commit_message=get_git_commit_message(),
+    )
+    experiment_run_token = experiment_run_var.set(experiment_run)
+
+    # The context variable is now available to the root span processor
+    try:
+        yield
+    finally:
+        # Clean up context
+        experiment_run_var.reset(experiment_run_token)

--- a/src/atla_insights/experiments.py
+++ b/src/atla_insights/experiments.py
@@ -55,7 +55,7 @@ def run_experiment(
 
     # The context variable is now available to the root span processor
     try:
-        yield
+        yield experiment_run
     finally:
         # Clean up context
         experiment_run_var.reset(experiment_run_token)

--- a/src/atla_insights/utils.py
+++ b/src/atla_insights/utils.py
@@ -1,10 +1,15 @@
 """Utility functions for Atla Insights."""
 
 import importlib
+from typing import Optional
 
 import opentelemetry.trace
+import pygit2
+from cuid2 import Cuid
 from opentelemetry.sdk.trace import TracerProvider as SDKTracerProvider
 from opentelemetry.trace import ProxyTracerProvider, get_tracer_provider
+
+_cuid_generator = Cuid()
 
 
 def truncate_value(value: str, max_chars: int) -> str:
@@ -34,3 +39,51 @@ def maybe_get_existing_tracer_provider() -> SDKTracerProvider | None:
         return None
 
     return existing_tracer_provider
+
+
+def get_git_repo() -> Optional[pygit2.Repository]:
+    """Get the current Git repository."""
+    try:
+        return pygit2.Repository(".")
+    except Exception:
+        return None
+
+
+def get_git_branch(repo: Optional[pygit2.Repository] = None) -> Optional[str]:
+    """Get the current Git branch name."""
+    try:
+        repo = repo or get_git_repo()
+        if repo.head_is_unborn:
+            return None
+        return repo.head.shorthand
+
+    except Exception:
+        return None
+
+
+def get_git_commit_hash(repo: Optional[pygit2.Repository] = None) -> Optional[str]:
+    """Get the current Git commit hash."""
+    try:
+        repo = repo or get_git_repo()
+        if repo.head_is_unborn:
+            return None
+        return str(repo.head.target)
+    except Exception:
+        return None
+
+
+def get_git_commit_message(repo: Optional[pygit2.Repository] = None) -> Optional[str]:
+    """Get the current Git commit message."""
+    try:
+        repo = repo or get_git_repo()
+        if repo.head_is_unborn:
+            return None
+        commit = repo[repo.head.target]
+        return commit.message.strip()
+    except Exception:
+        return None
+
+
+def generate_cuid() -> str:
+    """Generate a new CUID."""
+    return _cuid_generator.generate()

--- a/src/atla_insights/utils.py
+++ b/src/atla_insights/utils.py
@@ -53,6 +53,8 @@ def get_git_branch(repo: Optional[pygit2.Repository] = None) -> Optional[str]:
     """Get the current Git branch name."""
     try:
         repo = repo or get_git_repo()
+        if repo is None:
+            return None
         if repo.head_is_unborn:
             return None
         return repo.head.shorthand
@@ -65,6 +67,8 @@ def get_git_commit_hash(repo: Optional[pygit2.Repository] = None) -> Optional[st
     """Get the current Git commit hash."""
     try:
         repo = repo or get_git_repo()
+        if repo is None:
+            return None
         if repo.head_is_unborn:
             return None
         return str(repo.head.target)
@@ -76,10 +80,12 @@ def get_git_commit_message(repo: Optional[pygit2.Repository] = None) -> Optional
     """Get the current Git commit message."""
     try:
         repo = repo or get_git_repo()
+        if repo is None:
+            return None
         if repo.head_is_unborn:
             return None
         commit = repo[repo.head.target]
-        return commit.message.strip()
+        return commit.message.strip()  # type: ignore[attr-defined]
     except Exception:
         return None
 

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -1,0 +1,223 @@
+"""Test the experiments functionality."""
+
+from unittest.mock import patch
+
+import pytest
+
+from atla_insights.context import experiment_run_var
+from tests._otel import BaseLocalOtel
+
+
+class TestExperiments(BaseLocalOtel):
+    """Test experiments functionality."""
+
+    def test_run_experiment_basic(self) -> None:
+        """Test basic experiment context manager functionality."""
+        from atla_insights import run_experiment
+
+        experiment_id = "test-experiment"
+        description = "Test experiment description"
+
+        with run_experiment(experiment_id, description) as exp_run:
+            # Check that we get an experiment run back
+            assert exp_run is not None
+            assert exp_run["experiment_id"] == experiment_id
+            assert exp_run["description"] == description
+            assert exp_run["id"] is not None
+            assert len(exp_run["id"]) > 0
+
+            # Check context variable is set
+            current_run = experiment_run_var.get()
+            assert current_run is not None
+            assert current_run["id"] == exp_run["id"]
+            assert current_run["experiment_id"] == experiment_id
+
+        # Check context variable is cleared after exiting
+        current_run = experiment_run_var.get()
+        assert current_run is None
+
+    def test_run_experiment_without_description(self) -> None:
+        """Test experiment without description."""
+        from atla_insights import run_experiment
+
+        experiment_id = "test-experiment-no-desc"
+
+        with run_experiment(experiment_id) as exp_run:
+            assert exp_run["experiment_id"] == experiment_id
+            assert exp_run["description"] is None
+            assert exp_run["id"] is not None
+
+    def test_run_experiment_unique_ids(self) -> None:
+        """Test that each experiment run gets a unique ID."""
+        from atla_insights import run_experiment
+
+        experiment_id = "test-experiment"
+        run_ids = []
+
+        for _ in range(3):
+            with run_experiment(experiment_id) as exp_run:
+                run_ids.append(exp_run["id"])
+
+        # All IDs should be unique
+        assert len(run_ids) == 3
+        assert len(set(run_ids)) == 3
+
+    def test_run_experiment_with_git_info(self) -> None:
+        """Test that Git information is captured correctly."""
+        from atla_insights import run_experiment
+
+        # Mock Git functions to return predictable values
+        with (
+            patch("atla_insights.experiments.get_git_branch", return_value="main"),
+            patch("atla_insights.experiments.get_git_commit_hash", return_value="abc123"),
+            patch(
+                "atla_insights.experiments.get_git_commit_message",
+                return_value="Test commit",
+            ),
+        ):
+            with run_experiment("test-experiment") as exp_run:
+                assert exp_run["git_branch"] == "main"
+                assert exp_run["git_commit_hash"] == "abc123"
+                assert exp_run["git_commit_message"] == "Test commit"
+
+    def test_run_experiment_with_no_git_info(self) -> None:
+        """Test behavior when Git information is not available."""
+        from atla_insights import run_experiment
+
+        # Mock Git functions to return None (no Git repo)
+        with (
+            patch("atla_insights.experiments.get_git_branch", return_value=None),
+            patch("atla_insights.experiments.get_git_commit_hash", return_value=None),
+            patch("atla_insights.experiments.get_git_commit_message", return_value=None),
+        ):
+            with run_experiment("test-experiment") as exp_run:
+                assert exp_run["git_branch"] is None
+                assert exp_run["git_commit_hash"] is None
+                assert exp_run["git_commit_message"] is None
+
+    def test_run_experiment_context_cleanup_on_exception(self) -> None:
+        """Test that context is properly cleaned up even when an exception occurs."""
+        from atla_insights import run_experiment
+
+        # Ensure context is initially clean
+        assert experiment_run_var.get() is None
+
+        with pytest.raises(ValueError, match="test error"):
+            with run_experiment("test-experiment"):
+                # Context should be set inside the context manager
+                assert experiment_run_var.get() is not None
+                raise ValueError("test error")
+
+        # Context should be cleaned up even after exception
+        assert experiment_run_var.get() is None
+
+    def test_run_experiment_nested_contexts(self) -> None:
+        """Test nested experiment contexts."""
+        from atla_insights import run_experiment
+
+        with run_experiment("outer-experiment") as outer_run:
+            outer_run_id = outer_run["id"]
+
+            # Check outer context is active
+            current_run = experiment_run_var.get()
+            assert current_run is not None
+            assert current_run["id"] == outer_run_id
+
+            with run_experiment("inner-experiment") as inner_run:
+                inner_run_id = inner_run["id"]
+
+                # Check inner context is now active
+                current_run = experiment_run_var.get()
+                assert current_run is not None
+                assert current_run["id"] == inner_run_id
+                assert current_run["experiment_id"] == "inner-experiment"
+
+            # Check outer context is restored
+            current_run = experiment_run_var.get()
+            assert current_run is not None
+            assert current_run["id"] == outer_run_id
+            assert current_run["experiment_id"] == "outer-experiment"
+
+        # Check all contexts are cleaned up
+        assert experiment_run_var.get() is None
+
+    def test_run_experiment_cuid_generation(self) -> None:
+        """Test that experiment runs use CUID for unique IDs."""
+        from atla_insights import run_experiment
+
+        with run_experiment("test-experiment") as exp_run:
+            run_id = exp_run["id"]
+
+            # CUID should be a string with specific characteristics
+            assert isinstance(run_id, str)
+            assert len(run_id) > 20  # CUIDs are typically > 20 characters
+            # CUIDs start with 'c' in cuid2
+            assert run_id[0].islower()
+
+    def test_run_experiment_context_isolation(self) -> None:
+        """Test that experiment contexts are isolated between different calls."""
+        from atla_insights import run_experiment
+        from atla_insights.context import experiment_run_var
+
+        def get_current_experiment_id():
+            """Helper to get current experiment ID from context."""
+            run = experiment_run_var.get()
+            return run["experiment_id"] if run else None
+
+        # Initially no context
+        assert get_current_experiment_id() is None
+
+        with run_experiment("experiment-1"):
+            assert get_current_experiment_id() == "experiment-1"
+
+        # Context should be cleared
+        assert get_current_experiment_id() is None
+
+        with run_experiment("experiment-2"):
+            assert get_current_experiment_id() == "experiment-2"
+
+        # Context should be cleared again
+        assert get_current_experiment_id() is None
+
+    def test_run_experiment_context_variable_types(self) -> None:
+        """Test that the experiment run context variable has correct types."""
+        from atla_insights import run_experiment
+
+        with run_experiment("test-experiment", "Test description") as exp_run:
+            # Check all fields have expected types
+            assert isinstance(exp_run["id"], str)
+            assert isinstance(exp_run["experiment_id"], str)
+            assert isinstance(exp_run["description"], str)
+
+            # Git fields can be None or str
+            assert exp_run["git_branch"] is None or isinstance(exp_run["git_branch"], str)
+            assert exp_run["git_commit_hash"] is None or isinstance(
+                exp_run["git_commit_hash"], str
+            )
+            assert exp_run["git_commit_message"] is None or isinstance(
+                exp_run["git_commit_message"], str
+            )
+
+    def test_run_experiment_concurrent_usage(self) -> None:
+        """Test that multiple experiment contexts can be used concurrently."""
+        from atla_insights import run_experiment
+
+        results = []
+
+        for i in range(5):
+            with run_experiment(f"experiment-{i}", f"Description {i}") as exp_run:
+                results.append(
+                    {
+                        "id": exp_run["id"],
+                        "experiment_id": exp_run["experiment_id"],
+                        "description": exp_run["description"],
+                    }
+                )
+
+        # All experiments should have unique run IDs but correct experiment IDs
+        run_ids = [r["id"] for r in results]
+        assert len(set(run_ids)) == 5  # All unique
+
+        for i, result in enumerate(results):
+            assert result["experiment_id"] == f"experiment-{i}"
+            assert result["description"] == f"Description {i}"

--- a/uv.lock
+++ b/uv.lock
@@ -219,6 +219,7 @@ name = "atla-insights"
 version = "0.0.20"
 source = { editable = "." }
 dependencies = [
+    { name = "cuid2" },
     { name = "httpx" },
     { name = "openai" },
     { name = "openinference-instrumentation" },
@@ -228,6 +229,7 @@ dependencies = [
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-instrumentation" },
     { name = "pydantic" },
+    { name = "pygit2" },
     { name = "python-dateutil" },
     { name = "rich" },
     { name = "wrapt" },
@@ -339,6 +341,7 @@ requires-dist = [
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.38.17" },
     { name = "claude-code-sdk", marker = "extra == 'claude-code-sdk'", specifier = ">=0.0.19" },
     { name = "crewai", marker = "extra == 'crewai'", specifier = ">=0.130.0" },
+    { name = "cuid2", specifier = ">=2.0.1" },
     { name = "google-genai", marker = "extra == 'google-genai'", specifier = ">=1.19.0" },
     { name = "google-generativeai", marker = "extra == 'google-generativeai'", specifier = ">=0.7.0" },
     { name = "httpx", specifier = ">=0.24.0" },
@@ -370,6 +373,7 @@ requires-dist = [
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.32.1" },
     { name = "opentelemetry-instrumentation", specifier = ">=0.54b0" },
     { name = "pydantic", specifier = ">=2.11.4" },
+    { name = "pygit2", specifier = ">=1.16.0" },
     { name = "pytest", marker = "extra == 'ci'", specifier = ">=8.3.4" },
     { name = "pytest-asyncio", marker = "extra == 'ci'", specifier = ">=0.26.0" },
     { name = "pytest-httpserver", marker = "extra == 'ci'", specifier = ">=1.1.3" },
@@ -846,6 +850,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/b9/a2f747d2acd5e3075fdf5c145c7c3568895daaa38b3b0c960ef830db6cdc/cryptography-45.0.6-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:31a2b9a10530a1cb04ffd6aa1cd4d3be9ed49f7d77a4dafe198f3b382f41545c", size = 4152706, upload-time = "2025-08-05T23:59:20.044Z" },
     { url = "https://files.pythonhosted.org/packages/81/ec/381b3e8d0685a3f3f304a382aa3dfce36af2d76467da0fd4bb21ddccc7b2/cryptography-45.0.6-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:e5b3dda1b00fb41da3af4c5ef3f922a200e33ee5ba0f0bc9ecf0b0c173958385", size = 4386740, upload-time = "2025-08-05T23:59:21.525Z" },
     { url = "https://files.pythonhosted.org/packages/0a/76/cf8d69da8d0b5ecb0db406f24a63a3f69ba5e791a11b782aeeefef27ccbb/cryptography-45.0.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:629127cfdcdc6806dfe234734d7cb8ac54edaf572148274fa377a7d3405b0043", size = 3331874, upload-time = "2025-08-05T23:59:23.017Z" },
+]
+
+[[package]]
+name = "cuid2"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/63/97ffc74f33e5a5f913bf073e8250a5b5a64d52d411b09a9c36c902db2cc4/cuid2-2.0.1.tar.gz", hash = "sha256:8d262eb467c16b81419361e18e47f41da77c4446dd2cf0640eac2616680bc924", size = 7033, upload-time = "2024-04-16T23:51:52.05Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/d2/90fce0050c5a9196d259ac8f0c4720c69ec6b5a322612edf3892f0036c5d/cuid2-2.0.1-py3-none-any.whl", hash = "sha256:943bdf86dc3ed07f32253e1be6e3c34dda8c7bda1c453f851f4ebaaa5a2dcfbf", size = 8154, upload-time = "2024-04-16T23:51:50.953Z" },
 ]
 
 [[package]]
@@ -3711,6 +3724,53 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/68/85/1ea668bbab3c50071ca613c6ab30047fb36ab0da1b92fa8f17bbc38fd36c/pydantic_settings-2.10.1.tar.gz", hash = "sha256:06f0062169818d0f5524420a360d632d5857b83cffd4d42fe29597807a1614ee", size = 172583, upload-time = "2025-06-24T13:26:46.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/58/f0/427018098906416f580e3cf1366d3b1abfb408a0652e9f31600c24a1903c/pydantic_settings-2.10.1-py3-none-any.whl", hash = "sha256:a60952460b99cf661dc25c29c0ef171721f98bfcb52ef8d9ea4c943d7c8cc796", size = 45235, upload-time = "2025-06-24T13:26:45.485Z" },
+]
+
+[[package]]
+name = "pygit2"
+version = "1.18.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/ea/762d00f6f518423cd889e39b12028844cc95f91a6413cf7136e184864821/pygit2-1.18.2.tar.gz", hash = "sha256:eca87e0662c965715b7f13491d5e858df2c0908341dee9bde2bc03268e460f55", size = 797200, upload-time = "2025-08-16T13:52:36.853Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/54/a747b5a80698c22b7e510de61facaf7b7dd196fe4540d0d28eb05eacaeba/pygit2-1.18.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a84fbc62b0d2103059559b5af7e939289a0f3fc7d0a7ad84d822eaa97a6db687", size = 5509510, upload-time = "2025-08-16T13:39:01.887Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/bc/865c6090efa25a5cfe7e1d2cec28c2515a2d7239d3b428f36184af6610ac/pygit2-1.18.2-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c84aa50acba5a2c6bb36863fbcc1d772dc00199f9ea41bb5cac73c5fdad42bce", size = 5762592, upload-time = "2025-08-16T13:39:03.06Z" },
+    { url = "https://files.pythonhosted.org/packages/41/96/69a408e57fd68555e1bdb134a15edb4cb77a24ba266dcbf6edf6d5d4a807/pygit2-1.18.2-cp310-cp310-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d7b8570f0df4f0a854c3d3bdcec4a5767b50b0acb13ef163f6b96db593e3611f", size = 4599930, upload-time = "2025-08-16T13:39:04.66Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/bc/ee2335c98995cce3dfec7ccd54fff027b769a839832457fa784fe14e4538/pygit2-1.18.2-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cccceadab2c772a52081eac4680c3664d2ff21966171d339fee6aaf303ccbe23", size = 5493592, upload-time = "2025-08-16T13:39:06.025Z" },
+    { url = "https://files.pythonhosted.org/packages/31/54/af78c3870c62b3bbfe86ed1f2ee1f46a8a43c1db70c0d35769365fa8b145/pygit2-1.18.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:c51e0b4a733e72212c86c8b3890a4c3572b1cae6d381e56b4d53ba3dafbeecf2", size = 5760887, upload-time = "2025-08-21T13:32:22.347Z" },
+    { url = "https://files.pythonhosted.org/packages/23/de/419658ecdbf37e89094b171b63c941774ff46d1bb6f65efd40f0c25d1df9/pygit2-1.18.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:970e9214e9146c893249acb9610fda9220fe048ae76c80fd7f36d0ec3381676b", size = 5460906, upload-time = "2025-08-16T13:39:07.633Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/91/bbaca03aa624915c4dd95c60961f34d683b069249c0f25d1faef29195873/pygit2-1.18.2-cp310-cp310-win32.whl", hash = "sha256:546f9b8e7bf9d88d77008a82d7d989c624f5756c4fba26af1b8985019985dc8a", size = 1238396, upload-time = "2025-08-16T13:10:33.39Z" },
+    { url = "https://files.pythonhosted.org/packages/53/a5/1d10b3e9d85ca62cbe5d5bbda611d3ca1f5fd0603910a00132b440bbbfd9/pygit2-1.18.2-cp310-cp310-win_amd64.whl", hash = "sha256:5383cdfc1315e7d49d7a59a9aa37c4f0f60d08c4de3137f31d20e4be2055ad47", size = 1323973, upload-time = "2025-08-16T13:15:10.479Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/c5/d3bd32443f4d7275928f7e07beb87b907401570e4a0b2d6b671909373d23/pygit2-1.18.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3fc89da1426793227e06f2dec5f2df98a0c6806fb4024eec6a125fb7a5042bbf", size = 5509503, upload-time = "2025-08-16T13:39:09.095Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e4/b26e970a493f65f646ec33ab77c462c6cb6b5527a11aa51b0b18bfe47642/pygit2-1.18.2-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:da6ab37a87b58032c596c37bcd0e3926cc6071748230f6f0911b7fe398e021ae", size = 5768944, upload-time = "2025-08-16T13:39:10.622Z" },
+    { url = "https://files.pythonhosted.org/packages/86/32/09d5ef009dd28529afcf377f4a767156fd105b58496405a815e4b66c1944/pygit2-1.18.2-cp311-cp311-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d9642f57943703de3651906f81b9535cb257b3cbe45ecca8f97cf475f1cb6b5f", size = 4606504, upload-time = "2025-08-16T13:39:12.131Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/2f/13fddef74a8dd6080e24a0bbd19c253e13e293f52c282596b9e3d0dc9148/pygit2-1.18.2-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1aa3efba6459e10608900fe26679e3b52ea566761f3e7ef9c0805d69a5548631", size = 5500249, upload-time = "2025-08-16T13:39:13.727Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c5/235376a6908a4b7cf25f92e3090e4f3f9828af49d021299a89eae66ecf9e/pygit2-1.18.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:25957ccf70e37f3e8020748724a14faf4731ceac69ed00ccbb422f99de0a80cc", size = 5767739, upload-time = "2025-08-21T13:33:47.707Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/1e/e2f914bfa0e8ca0b7c518c32d1b2183254c21d7d1eca3e21d6aeb7ccf066/pygit2-1.18.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6c9cdbad0888d664b80f30efda055c4c5b8fdae22c709bd57b1060daf8bde055", size = 5467750, upload-time = "2025-08-16T13:39:15.414Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/96/ac263bc9ce48a4f9cc31437dcaa812cc893382a8837c32cfe4764b03127e/pygit2-1.18.2-cp311-cp311-win32.whl", hash = "sha256:91bde9503ad35be55c95251c9a90cfe33cd608042dcc08d3991ed188f41ebec2", size = 1238394, upload-time = "2025-08-16T13:19:37.689Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/98/7fae3f7779469f2f4514e20d887d4011953c0a996af4b7f6b8bb73de4c0f/pygit2-1.18.2-cp311-cp311-win_amd64.whl", hash = "sha256:840d01574e164d9d2428d36d9d32d377091ac592a4b1a3aa3452a5342a3f6175", size = 1324157, upload-time = "2025-08-16T13:24:17.196Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/bf/469ec748d9d7989e5494eb5210f0752be4fb6b6bf892f9608cd2a1154dda/pygit2-1.18.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:5eaf2855d78c5ad2a6c2ebf840f8717a8980c93567a91fbc0fc91650747454a4", size = 5504679, upload-time = "2025-08-16T13:39:17.017Z" },
+    { url = "https://files.pythonhosted.org/packages/40/95/da254224e3d60a0b5992e0fe8dee3cadfd959ee771375eb0ee921f77e636/pygit2-1.18.2-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee5dd227e4516577d9edc2b476462db9f0428d3cc1ad5de32e184458f25046ee", size = 5769675, upload-time = "2025-08-16T13:39:18.691Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/cd/722e71b832b9c0d28482e15547d6993868e64e15becee5d172b51d4a6fed/pygit2-1.18.2-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:07e5c39ed67e07dac4eb99bfc33d7ccc105cd7c4e09916751155e7da3e07b6bc", size = 4605744, upload-time = "2025-08-16T13:39:20.153Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/50/70f38159f6783b54abcd74f47617478618f98a7f68370492777c9db42156/pygit2-1.18.2-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:12ae4ed05b48bb9f08690c3bb9f96a37a193ed44e1a9a993509a6f1711bb22ae", size = 5504072, upload-time = "2025-08-16T13:39:21.834Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/79/5648354eeefb85782e7b66c28ac27c1d6de51fd71b716fa59956fd7d6e30/pygit2-1.18.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:00919a2eafd975a63025d211e1c1a521bf593f6c822bc61f18c1bc661cbffd42", size = 5768382, upload-time = "2025-08-21T13:36:33.4Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e7/a679120119e92dcdbeb8add6655043db3bc7746d469b7dfc744667ebcd33/pygit2-1.18.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3f96a168bafb99e99b95f59b0090171396ad2fb07713e5505ad3e4c16a41d56a", size = 5472093, upload-time = "2025-08-16T13:39:23.031Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/54/e8c616a8fe12f80af64cfb9a7cba5f9455ca19c8ce68e5ef1d11d6a61d85/pygit2-1.18.2-cp312-cp312-win32.whl", hash = "sha256:ff1c99f2f342c3a3ec1847182d236088f1eb32bc6c4f93fbb5cb2514ccbe29f3", size = 1239180, upload-time = "2025-08-16T13:28:53.788Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/02/f4e51309c709f53575ceec53d74917cd2be536751d4d53f345a6b5427ad4/pygit2-1.18.2-cp312-cp312-win_amd64.whl", hash = "sha256:507b5ea151cb963b77995af0c4fb51333f02f15a05c0b36c33cd3f5518134ceb", size = 1324567, upload-time = "2025-08-16T13:33:51.181Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/ff/34dc8ce51f2f9ba39a5f2b34b9a5d70563cc93a387accf562c5c36e40d2b/pygit2-1.18.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f65d6114d96cb7a21cc09e8cb0622d0388619adf9cdb5d77d94589a41996b0a8", size = 5504646, upload-time = "2025-08-16T13:39:24.164Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/b6/7990c465a5a6967df87323a8a90e19e9b393d238497c62d0aabcb98b9d62/pygit2-1.18.2-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9367df01958f7e538bc3fc665ace55de0d5b72da5b6b5f95c44ae916c39a6f51", size = 5771485, upload-time = "2025-08-16T13:39:25.386Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ad/c31064927a11cb39d4860bbf3a1a1bd944d9768e9c8faaa48b670e9359ed/pygit2-1.18.2-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:eb2993e44aaafac5bcd801c2926dcf87c3f8939ff1c5fb9fe0549a81acd27a03", size = 4607179, upload-time = "2025-08-16T13:39:27.264Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/da/29a3c808bfb42ba86e5aca226fad7871b65fc216e18e14190553a879157b/pygit2-1.18.2-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d5dc116d6054cb4e970160c09440da7ded36acfbc4f06ef8e0d38ac275ee12", size = 5505911, upload-time = "2025-08-16T13:39:28.623Z" },
+    { url = "https://files.pythonhosted.org/packages/14/ac/c5afc7dd8ec0deb022ec8bbb5c938725438c40531ab9b6ad2b2d37730c59/pygit2-1.18.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3b87e7ab87da09145cb45434e6ad0402695ca72ffb764487ecc09d28abef5507", size = 5770236, upload-time = "2025-08-21T13:37:22.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d1/1c6882900bf6e0d3d5764937acab7c79ffadb452e33230ba8e5e9dc35695/pygit2-1.18.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a0aa809fd5572c8b1123270263720e458afc9e2069e8d0c1079feebc930e6813", size = 5474235, upload-time = "2025-08-16T13:39:30.274Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/be/7d8233ff8c5b39ca3d4309fa35a097999baa755e92303102599680c05604/pygit2-1.18.2-cp313-cp313-win32.whl", hash = "sha256:8c4423b08786d0fcea0c523b82bc5ec52039b01500a3391472786e89cadf1069", size = 1239177, upload-time = "2025-08-16T13:38:39.619Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/f8/d61973ec64a6a7afabec5d1308794399797b44daaacf7ae1969b0f83ddab/pygit2-1.18.2-cp313-cp313-win_amd64.whl", hash = "sha256:aeba6398d5c689c90c133e07f698aeb9f9693cfbb5707fccffd18f2d67d37c6d", size = 1324597, upload-time = "2025-08-16T13:43:31.309Z" },
+    { url = "https://files.pythonhosted.org/packages/17/3f/da4563009011dd5e4427740ca7fe3f1005158bf6c6670727e8e9d6078d8a/pygit2-1.18.2-pp310-pypy310_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd82d37cf5ce474a74388a04b9fb3c28670f44bc7fe970cabbb477a4d1cb871f", size = 5318756, upload-time = "2025-08-16T13:39:31.435Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/08/0aae26a1c74aedfe99b6f529011cd6e9f335f7840a0e92aeaa4620bcf117/pygit2-1.18.2-pp310-pypy310_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:991fe6bcbe914507abfe81be1c96bd5039ec315354e4132efffcb03eb8b363fb", size = 5043500, upload-time = "2025-08-16T13:39:33.006Z" },
+    { url = "https://files.pythonhosted.org/packages/57/91/f6655a5d171c0a080a7507b8d6855067f4365b326c0d946c6af12a633a80/pygit2-1.18.2-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d801d272f6331e067bd0d560671311d1ce4bb8f81536675706681ed44cc0d7dc", size = 5317765, upload-time = "2025-08-16T13:39:34.222Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/c8/288d1a56092b3e01524d03eeff24a85efc4eaa3861c6813e3098cde9ee02/pygit2-1.18.2-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2e1ff2d60420c98e6e25fd188069cddf8fa7b0417db7405ce7677a2f546e6b03", size = 5042134, upload-time = "2025-08-16T13:39:35.871Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
> [!NOTE]
> This should not be released until the backend is set up to process traces with these metadata tags.

Add support for running experiments with an `experiment_id` from the Atla Insights platform.

Example usage:

```
def main() -> None:
    """Main function."""
    # Configure the client. Experiments run in the "dev" environment by default,
    # but setting this here avoids a warning.
    configure(
        token=os.environ["ATLA_INSIGHTS_TOKEN"],
        environment="dev",
    )

    # Create an OpenAI client
    client = OpenAI()

    # Instrument the OpenAI client
    instrument_openai()

    # Run your app in the context of an experiment.
    # Your traces with be associated with a new run for the experiment.
    with run_experiment(experiment_id="123"):
        my_app(client)
```