### PR TITLE
Fix: Recursion error in Google Gen AI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "atla-insights"
-version = "0.0.20"
+version = "0.0.21"
 description = "Atla is a platform for monitoring and improving AI agents."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/atla_insights/llm_providers/instrumentors/google_genai.py
+++ b/src/atla_insights/llm_providers/instrumentors/google_genai.py
@@ -240,10 +240,8 @@ class AtlaGoogleGenAIInstrumentor(GoogleGenAIInstrumentor):
             "_atla_original_get_extra_attributes_from_request",
         ):
             (
-                _RequestAttributesExtractor._atla_original_get_extra_attributes_from_request
-            ) = (  # type: ignore[attr-defined]
-                _RequestAttributesExtractor.get_extra_attributes_from_request
-            )
+                _RequestAttributesExtractor._atla_original_get_extra_attributes_from_request  # type: ignore[attr-defined]
+            ) = _RequestAttributesExtractor.get_extra_attributes_from_request
 
             def get_extra_attributes_from_request(
                 self: _RequestAttributesExtractor, request_parameters: Mapping[str, Any]
@@ -265,10 +263,8 @@ class AtlaGoogleGenAIInstrumentor(GoogleGenAIInstrumentor):
             "_atla_original_get_attributes_from_content_parts",
         ):
             (
-                _ResponseAttributesExtractor._atla_original_get_attributes_from_content_parts
-            ) = (  # type: ignore[attr-defined]
-                _ResponseAttributesExtractor._get_attributes_from_content_parts
-            )
+                _ResponseAttributesExtractor._atla_original_get_attributes_from_content_parts  # type: ignore[attr-defined]
+            ) = _ResponseAttributesExtractor._get_attributes_from_content_parts
 
             def _get_attributes_from_content_parts(
                 self: _ResponseAttributesExtractor,

--- a/tests/llm_providers/test_google_genai.py
+++ b/tests/llm_providers/test_google_genai.py
@@ -1,5 +1,8 @@
 """Test the Google GenAI instrumentation."""
 
+import asyncio
+import random
+import sys
 from typing import Any, Iterable, Iterator, Mapping, Tuple
 
 import pytest
@@ -70,6 +73,52 @@ class TestGoogleGenAIInstrumentation(BaseLocalOtel):
         assert (
             span.attributes.get("llm.output_messages.0.message.content") == "hello world"
         )
+
+    @pytest.mark.asyncio
+    async def test_no_recursion_asyncio_race(
+        self, mock_google_genai_client: Client
+    ) -> None:
+        """Async race of (un)instrumentation must not cause recursion in wrappers."""
+        num_tasks = 10
+        iterations = 10
+        stop_event = asyncio.Event()
+        recursion_errors: list[BaseException] = []
+
+        original_limit = sys.getrecursionlimit()
+        sys.setrecursionlimit(99)
+        try:
+            from atla_insights import instrument_google_genai
+
+            async def worker() -> None:
+                try:
+                    for _ in range(iterations):
+                        if stop_event.is_set():
+                            return
+                        with instrument_google_genai():
+                            # short await to encourage interleaving
+                            await asyncio.sleep(random.uniform(0, 0.002))
+
+                    # Make a call under instrumentation
+                    with instrument_google_genai():
+                        mock_google_genai_client.models.generate_content(
+                            model="some-model",
+                            contents="Hello, World!",
+                        )
+                except RecursionError as e:
+                    recursion_errors.append(e)
+                    stop_event.set()
+
+            await asyncio.gather(*(worker() for _ in range(num_tasks)))
+
+            assert not recursion_errors, (
+                f"Unexpected RecursionError(s): {recursion_errors}"
+            )
+
+            # At least one span should be produced by the final calls
+            finished_spans = self.get_finished_spans()
+            assert len(finished_spans) >= 1
+        finally:
+            sys.setrecursionlimit(original_limit)
 
     def test_tool_calls(self, mock_google_genai_client: Client) -> None:
         """Test Google GenAI instrumentation with tool calls."""

--- a/uv.lock
+++ b/uv.lock
@@ -216,7 +216,7 @@ wheels = [
 
 [[package]]
 name = "atla-insights"
-version = "0.0.20"
+version = "0.0.21"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Issue reported with traceback:

```
"Traceback (most recent call last): File "/usr/local/lib/python3.12/site-packages/openinference/instrumentation/google_genai/_utils.py", line 76, in _finish_tracing extra_attributes_dict = dict(extra_attributes) ^^^^^^^^^^^^^^^^^^^^^^ File "/usr/local/lib/python3.12/site-packages/openinference/instrumentation/google_genai/_response_attributes_extractor.py", line 29, in get_extra_attributes yield from self._get_attributes_from_generate_content( File "/usr/local/lib/python3.12/site-packages/openinference/instrumentation/google_genai/_response_attributes_extractor.py", line 58, in _get_attributes_from_generate_content for key, value in self._get_attributes_from_generate_content_content(content): ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/usr/local/lib/python3.12/site-packages/openinference/instrumentation/google_genai/_response_attributes_extractor.py", line 66, in _get_attributes_from_generate_content_content yield from self._get_attributes_from_content_parts(content_parts) File "/usr/local/lib/python3.12/site-packages/atla_insights/llm_providers/instrumentors/google_genai.py", line 261, in _get_attributes_from_content_parts yield from original_get_attributes_from_content_parts(self, content_parts) File "/usr/local/lib/python3.12/site-packages/atla_insights/llm_providers/instrumentors/google_genai.py", line 261, in _get_attributes_from_content_parts yield from original_get_attributes_from_content_parts(self, content_parts) File "/usr/local/lib/python3.12/site-packages/atla_insights/llm_providers/instrumentors/google_genai.py", line 261, in _get_attributes_from_content_parts yield from original_get_attributes_from_content_parts(self, content_parts) [Previous line repeated 970 more times] RecursionError: maximum recursion depth exceeded"
```

Candidate source of the error:
- Rapid re-instrumentation that meant that the `_ResponseAttributesExtractor._get_attributes_from_content_parts` function was being wrapped by itself from a previous instrumentation call.
- Added a demonstrative test case that reproduces the issue when the fix is not applied
- Solved by writing the wrapped function to a separate namespace, and ensuring that use that function if already present