### PR TITLE
Feature/tail sampler

### DIFF
--- a/examples/metadata_sampling.py
+++ b/examples/metadata_sampling.py
@@ -1,0 +1,52 @@
+"""Basic instrumentation example."""
+
+import os
+from typing import Optional
+
+from atla_insights import configure, instrument, set_metadata
+from atla_insights.sampling import MetadataSampler
+
+
+@instrument("The function I want to sample")
+def feature_1() -> str:
+    """The function I want to sample."""
+    set_metadata({"feature": "feature_1"})
+    return "Hello, world!"
+
+
+@instrument("The function I don't want to sample")
+def feature_2() -> str:
+    """The function I don't want to sample."""
+    set_metadata({"feature": "feature_2"})
+    return "Hello, world!"
+
+
+def sampling_fn(metadata: Optional[dict[str, str]]) -> bool:
+    """Decision function for metadata sampling.
+
+    :param metadata (Optional[dict[str, str]]): The metadata to sample.
+    :return (bool): Whether to sample the trace.
+    """
+    if metadata is None:
+        return False
+
+    return metadata.get("feature") == "feature_1"
+
+
+def main() -> None:
+    """Main function."""
+    # Configure the client
+    configure(
+        token=os.environ["ATLA_INSIGHTS_TOKEN"],
+        sampler=MetadataSampler(sampling_fn),
+    )
+
+    # Calling the instrumented function will create a span behind the scenes
+    feature_1()
+
+    # Calling the instrumented function will create a span behind the scenes
+    feature_2()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/metadata_sampling.py
+++ b/examples/metadata_sampling.py
@@ -41,10 +41,10 @@ def main() -> None:
         sampler=MetadataSampler(sampling_fn),
     )
 
-    # Calling the instrumented function will create a span behind the scenes
+    # This will be sampled
     feature_1()
 
-    # Calling the instrumented function will create a span behind the scenes
+    # This will not be sampled
     feature_2()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "atla-insights"
-version = "0.0.23"
+version = "0.0.24"
 description = "Atla is a platform for monitoring and improving AI agents."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/atla_insights/sampling.py
+++ b/src/atla_insights/sampling.py
@@ -1,62 +1,223 @@
 """OpenTelemetry samplers for Atla Insights."""
 
+import json
 import logging
-from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from typing import Union, get_args
+import threading
+import time
+from typing import Callable, Optional, Union
 
-from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.context import Context
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace.export import SpanExporter, SpanProcessor
 from opentelemetry.sdk.trace.sampling import (
     ParentBased,
     ParentBasedTraceIdRatio,
-    Sampler,
     StaticSampler,
 )
+
+from atla_insights.constants import METADATA_MARK
 
 logger = logging.getLogger("atla_insights")
 
 
-TRACE_SAMPLER_TYPE = Union[ParentBased, StaticSampler]
+# Alias chosen opentelemetry samplers for convenience (Atla is not guaranteed to work
+# well with any sampler (particularly non static or parent-based samplers))
+TraceRatioSampler = ParentBasedTraceIdRatio
 
 
-class _HeadSamplingOptions(ABC):
-    """Base class for head sampling options."""
+class _TailSampler(SpanProcessor):
+    """General tail-based sampler class.
 
-    @abstractmethod
-    def to_sampler(self) -> TRACE_SAMPLER_TYPE:
-        pass
+    Buffers spans per trace and makes an export decision once the trace is complete.
+    """
+
+    def __init__(
+        self,
+        decision_fn: Callable[[list[ReadableSpan]], bool],
+        linger_ms: int = 5 * 60 * 1000,
+        reap_interval_ms: int = 2 * 60 * 1000,
+        max_traces: int = 50_000,
+        max_spans_per_trace: int = 10_000,
+    ) -> None:
+        """Initialize the TailSamplingSpanProcessor."""
+        self._exporters: list[SpanExporter] = []
+        self._decide = decision_fn
+
+        self._linger_ms = linger_ms
+        self._reap_interval_ms = reap_interval_ms
+        self._max_traces = max_traces
+        self._max_spans_per_trace = max_spans_per_trace
+
+        self._traces: dict[int, dict[str, object]] = {}
+        self._lock = threading.RLock()
+        self._shutdown = False
+
+        self._reaper = threading.Thread(
+            target=self._reap_loop, name="atla-tail-sampling-reaper", daemon=True
+        )
+        self._reaper.start()
+
+    def add_exporter(self, exporter: SpanExporter) -> None:
+        """Add an exporter to the TailSampler."""
+        self._exporters.append(exporter)
+
+    def on_start(
+        self, span: ReadableSpan, parent_context: Optional[Context] = None
+    ) -> None:
+        """On start span processing.
+
+        :param span (ReadableSpan): The span to process.
+        :param parent_context (Optional[Context]): The parent context. Defaults to `None`.
+        """
+        if self._shutdown:
+            return
+
+        trace_id = span.context.trace_id
+        now = time.time()
+        with self._lock:
+            state = self._traces.get(trace_id)
+            if state is None:
+                if len(self._traces) >= self._max_traces:
+                    self._traces.pop(next(iter(self._traces)))
+                state = {
+                    "spans": [],
+                    "open": 0,
+                    "root_seen": False,
+                    "first_seen": now,
+                    "last_update": now,
+                }
+                self._traces[trace_id] = state
+            state["open"] = int(state["open"]) + 1  # type: ignore
+            state["last_update"] = now
+
+    def on_end(self, span: ReadableSpan) -> None:
+        """On end span processing.
+
+        :param span (ReadableSpan): The span to process.
+        """
+        if self._shutdown:
+            return
+
+        trace_id = span.context.trace_id
+        now = time.time()
+        with self._lock:
+            state = self._traces.get(trace_id)
+            if state is None:
+                state = {
+                    "spans": [],
+                    "open": 0,
+                    "root_seen": False,
+                    "first_seen": now,
+                    "last_update": now,
+                }
+                self._traces[trace_id] = state
+
+            spans_list: list[ReadableSpan] = state["spans"]  # type: ignore
+
+            if len(spans_list) < self._max_spans_per_trace:
+                spans_list.append(span)
+
+            state["open"] = max(0, int(state["open"]) - 1)  # type: ignore
+            state["last_update"] = now
+
+            if span.parent is None:
+                state["root_seen"] = True
+
+            if state["root_seen"] and int(state["open"]) == 0:  # type: ignore
+                self._finalize_trace_locked(trace_id)
+
+    def shutdown(self) -> None:
+        """Shutdown the TailSampler."""
+        with self._lock:
+            if self._shutdown:
+                return
+            self._shutdown = True
+
+        self.force_flush()
+        for exporter in self._exporters:
+            exporter.shutdown()
+
+    def force_flush(self, timeout_millis: int = 30_000) -> bool:
+        """Force flush the TailSampler."""
+        deadline = time.time() + timeout_millis / 1000.0
+
+        with self._lock:
+            trace_ids = list(self._traces.keys())
+
+        for tid in trace_ids:
+            with self._lock:
+                if tid in self._traces:
+                    self._maybe_finalize_by_time_locked(tid, force=True)
+
+        remaining = max(0, deadline - time.time())
+        end = time.time() + remaining
+        return time.time() <= end
+
+    def _reap_loop(self) -> None:
+        """Reap loop for the TailSampler."""
+        while not self._shutdown:
+            time.sleep(self._reap_interval_ms / 1000.0)
+            now = time.time()
+            expired: list[int] = []
+            with self._lock:
+                for tid, state in list(self._traces.items()):
+                    last_update = float(state["last_update"])  # type: ignore
+                    if (now - last_update) * 1000.0 >= self._linger_ms:
+                        expired.append(tid)
+                for tid in expired:
+                    if tid in self._traces:
+                        self._maybe_finalize_by_time_locked(tid, force=False)
+
+    def _maybe_finalize_by_time_locked(self, trace_id: int, force: bool) -> None:
+        """Finalize a trace if linger elapsed and root has ended (or force=True)."""
+        state = self._traces.get(trace_id)
+        if state is None:
+            return
+
+        root_seen = bool(state["root_seen"])
+        if force or root_seen:
+            self._finalize_trace_locked(trace_id)
+
+    def _finalize_trace_locked(self, trace_id: int) -> None:
+        """Finalize a trace if root has ended."""
+        state = self._traces.pop(trace_id, None)
+        if not state:
+            return
+        spans_list: list[ReadableSpan] = state["spans"]  # type: ignore
+
+        try:
+            export_this_trace = self._decide(spans_list)
+        except Exception:
+            export_this_trace = False
+
+        if export_this_trace and spans_list:
+            for exporter in self._exporters:
+                exporter.export(spans_list)
 
 
-TRACE_SAMPLING_TYPE = Union[TRACE_SAMPLER_TYPE, _HeadSamplingOptions]
+class MetadataSampler(_TailSampler):
+    """Sampler based on metadata."""
+
+    def __init__(self, decision_fn: Callable[[Optional[dict[str, str]]], bool]) -> None:
+        """Initialize the MetadataSampler."""
+
+        def _decision_fn(spans: list[ReadableSpan]) -> bool:
+            """Helper function that extracts metadata from root span and passes it on.
+
+            :param spans (list[ReadableSpan]): The spans to process.
+            :return (bool): The decision to export the trace.
+            """
+            decision = True  # default open
+            for span in spans:
+                if span.parent is None and span.attributes is not None:
+                    metadata = span.attributes.get(METADATA_MARK)
+                    decision = decision_fn(
+                        json.loads(str(metadata)) if metadata else None
+                    )
+                    break
+            return decision
+
+        super().__init__(_decision_fn)
 
 
-@dataclass
-class TraceRatioSamplingOptions(_HeadSamplingOptions):
-    """Options for trace ratio sampling."""
-
-    rate: float
-
-    def to_sampler(self) -> TRACE_SAMPLER_TYPE:
-        """Convert the sampling options to a sampler."""
-        return ParentBasedTraceIdRatio(self.rate)
-
-
-def add_sampling_to_tracer_provider(
-    tracer_provider: TracerProvider,
-    sampling: TRACE_SAMPLING_TYPE,
-) -> None:
-    """Add sampling to a tracer provider."""
-    if isinstance(sampling, Sampler):
-        if not isinstance(sampling, get_args(TRACE_SAMPLER_TYPE)):
-            logger.warning(
-                "Passed a custom sampler that is not `ParentBased` or `StaticSampler`. "
-                "This can result in partial traces being sent to Atla Insights and "
-                "unexpected behavior! It is strongly recommended to use a `ParentBased` "
-                "or `StaticSampler` instead."
-            )
-        tracer_provider.sampler = sampling
-    elif isinstance(sampling, _HeadSamplingOptions):
-        sampler = sampling.to_sampler()
-        tracer_provider.sampler = sampler
-    else:
-        logger.warning(f"Unrecognized sampling type: `{type(sampling)}`")
+SamplerType = Union[ParentBased, StaticSampler, _TailSampler]

--- a/src/atla_insights/span_processors.py
+++ b/src/atla_insights/span_processors.py
@@ -2,14 +2,12 @@
 
 import json
 import warnings
-from typing import Optional, Sequence
+from typing import Optional
 
 from opentelemetry.context import Context
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor, TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor
+from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
 
-from atla_insights.console_span_exporter import ConsoleSpanExporter
 from atla_insights.constants import (
     ENVIRONMENT_MARK,
     EXPERIMENT_RUN_NAMESPACE,
@@ -69,57 +67,9 @@ class AtlaRootSpanProcessor(SpanProcessor):
         pass
 
 
-def get_atla_span_processor(token: str) -> SpanProcessor:
-    """Get an Atla span processor.
-
-    :param token (str): The write access token.
-    :return (SpanProcessor): An Atla span processor.
-    """
-    span_exporter = OTLPSpanExporter(
+def get_atla_span_exporter(token: str) -> OTLPSpanExporter:
+    """Get the Atla span exporter."""
+    return OTLPSpanExporter(
         endpoint=OTEL_TRACES_ENDPOINT,
         headers={"Authorization": f"Bearer {token}"},
     )
-    return SimpleSpanProcessor(span_exporter)
-
-
-def get_atla_console_span_processor() -> BatchSpanProcessor:
-    """Get an Atla console span processor.
-
-    :return (BatchSpanProcessor): An Atla console span processor.
-    """
-    span_exporter = ConsoleSpanExporter()
-    return BatchSpanProcessor(span_exporter)
-
-
-def add_span_processors_to_tracer_provider(
-    tracer_provider: TracerProvider,
-    token: str,
-    additional_span_processors: Optional[Sequence[SpanProcessor]],
-    verbose: bool,
-    debug: bool,
-    environment: str,
-) -> None:
-    """Adds all relevant span processors to a tracer provider.
-
-    :param tracer_provider (TracerProvider): The tracer provider to add the span
-        processors to.
-    :param token (str): The write access token.
-    :param additional_span_processors (Optional[Sequence[SpanProcessor]]): Additional
-        span processors.
-    :param verbose (bool): Whether to print verbose output to console.
-    :param debug (bool): Whether to log debug outputs.
-    :param environment (SUPPORTED_ENVIRONMENT): The environment ("dev" or "prod").
-    """
-    span_processors = [
-        get_atla_span_processor(token),
-        AtlaRootSpanProcessor(debug, environment),
-    ]
-
-    if additional_span_processors:
-        span_processors.extend(additional_span_processors)
-
-    if verbose:
-        span_processors.append(get_atla_console_span_processor())
-
-    for span_processor in span_processors:
-        tracer_provider.add_span_processor(span_processor)

--- a/tests/_otel.py
+++ b/tests/_otel.py
@@ -1,5 +1,6 @@
 """OpenTelemetry assets to be used in instrumentation tests."""
 
+import importlib
 import time
 
 import litellm
@@ -26,3 +27,10 @@ class BaseLocalOtel:
             in_memory_span_exporter.get_finished_spans(),
             key=lambda x: x.start_time if x.start_time is not None else 0,
         )
+
+
+def reset_tracer_provider() -> None:
+    """Reset the tracer provider."""
+    import opentelemetry.trace
+
+    importlib.reload(opentelemetry.trace)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,6 @@ from botocore.stub import ANY, Stubber
 from google.genai import Client
 from google.genai.types import HttpOptions
 from openai import AsyncAzureOpenAI, AsyncOpenAI, AzureOpenAI, OpenAI
-from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from pytest_httpserver import HTTPServer
 
@@ -26,16 +25,14 @@ with open(Path(__file__).parent / "test_data" / "mock_responses.json", "r") as f
     _MOCK_RESPONSES = json.load(f)
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(autouse=True)
 def mock_configure() -> None:
     """Mock Atla configuration to send traces to a local object instead."""
     from atla_insights import configure
 
-    span_processor = SimpleSpanProcessor(in_memory_span_exporter)
-
     with patch(
-        "atla_insights.span_processors.get_atla_span_processor",
-        return_value=span_processor,
+        "atla_insights.main.get_atla_span_exporter",
+        return_value=in_memory_span_exporter,
     ):
         configure(token="dummy", metadata={"environment": "unit-testing"}, verbose=False)
 

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -123,13 +123,13 @@ class TestEnvironment(BaseLocalOtel):
         atla_instance = AtlaInsights()
 
         with patch(
-            "atla_insights.main.add_span_processors_to_tracer_provider"
-        ) as mock_add_processors:
+            "atla_insights.main.AtlaInsights._setup_tracer_provider"
+        ) as mock_setup_tracer_provider:
             atla_instance.configure(token="dummy", environment="dev")
 
-            # Verify add_span_processors_to_tracer_provider was called with env="dev"
-            mock_add_processors.assert_called_once()
-            call_args = mock_add_processors.call_args
+            # Verify _setup_tracer_provider was called with env="dev"
+            mock_setup_tracer_provider.assert_called_once()
+            call_args = mock_setup_tracer_provider.call_args
             assert call_args.kwargs["environment"] == "dev"
 
     @patch.dict(os.environ, {"ATLA_INSIGHTS_ENVIRONMENT": "dev"})
@@ -142,12 +142,12 @@ class TestEnvironment(BaseLocalOtel):
         atla_instance = AtlaInsights()
 
         with patch(
-            "atla_insights.main.add_span_processors_to_tracer_provider"
-        ) as mock_add_processors:
+            "atla_insights.main.AtlaInsights._setup_tracer_provider"
+        ) as mock_setup_tracer_provider:
             atla_instance.configure(token="dummy")  # No environment parameter
 
             # Verify environment variable was picked up
-            call_args = mock_add_processors.call_args
+            call_args = mock_setup_tracer_provider.call_args
             assert call_args.kwargs["environment"] == "dev"
 
     @patch.dict(os.environ, {"ATLA_INSIGHTS_ENVIRONMENT": "dev"})
@@ -160,13 +160,13 @@ class TestEnvironment(BaseLocalOtel):
         atla_instance = AtlaInsights()
 
         with patch(
-            "atla_insights.main.add_span_processors_to_tracer_provider"
-        ) as mock_add_processors:
+            "atla_insights.main.AtlaInsights._setup_tracer_provider"
+        ) as mock_setup_tracer_provider:
             # Environment variable is "dev" but parameter is "prod"
             atla_instance.configure(token="dummy", environment="prod")
 
             # Verify parameter took precedence over environment variable
-            call_args = mock_add_processors.call_args
+            call_args = mock_setup_tracer_provider.call_args
             assert call_args.kwargs["environment"] == "prod"
 
     def test_configure_with_invalid_environment_parameter(self) -> None:

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -129,22 +129,22 @@ class TestSampling(BaseLocalOtel):
             configure(token="dummy", sampler=MetadataSampler(decision_fn), verbose=False)
 
         @instrument("some_func")
-        def test_function():
+        def test_function_1():
             set_metadata({"should_sample": "false"})
             return "test result"
 
-        test_function()
+        test_function_1()
 
         spans = self.get_finished_spans()
 
         assert len(spans) == 0
 
         @instrument("some_func")
-        def test_function():
+        def test_function_2():
             set_metadata({"should_sample": "true"})
             return "test result"
 
-        test_function()
+        test_function_2()
 
         spans = self.get_finished_spans()
 

--- a/uv.lock
+++ b/uv.lock
@@ -216,7 +216,7 @@ wheels = [
 
 [[package]]
 name = "atla-insights"
-version = "0.0.23"
+version = "0.0.24"
 source = { editable = "." }
 dependencies = [
     { name = "cuid2" },


### PR DESCRIPTION
Add support for tail sampling (i.e., make a sampling decision based on information that will become available throughout the creation of a trace).

This PR:
- Adds general support for `_TailSampler` with any arbitrary decision function that is mapped over all spans in a trace
- Adds user-friendly support for `MetadataSampler` where users can write a decision function specifically on metadata fields without having to go through the effort of extracting metadata from the trace span attributes
- Refactors the way we approached sampling. We used to work with Samplers & `SamplingOptions` to provide a seamless user experience & abstract away the complexity of tail samplers. However, in our tail sampling implementation, we pass it as a span processor rather than an actual Sampler object (for technical reasons). The previous design would have added significant complexity for no real benefit, so this PR proposes a new, simpler interface