### PR TITLE
Disable exclusive processing for openai agents sdk

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "atla-insights"
-version = "0.0.28"
+version = "0.0.29"
 description = "Atla is a platform for monitoring and improving AI agents."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/atla_insights/frameworks/instrumentors/openai_agents.py
+++ b/src/atla_insights/frameworks/instrumentors/openai_agents.py
@@ -33,13 +33,18 @@ class AtlaOpenAIAgentsInstrumentor(OpenAIAgentsInstrumentor):
 
     name = "openai-agents"
 
+    def __init__(self, exclusive_processor: bool) -> None:
+        """Initialize the Atla OpenAI Agents SDK instrumentor class."""
+        self.exclusive_processor = exclusive_processor
+        super().__init__()
+
     def _instrument(self, **kwargs: Any) -> None:
         wrap_function_wrapper(
             "openinference.instrumentation.openai_agents._processor",
             "_get_attributes_from_function_span_data",
             _get_attributes_from_function_span_data,
         )
-        super()._instrument(**kwargs)
+        super()._instrument(exclusive_processor=self.exclusive_processor, **kwargs)
 
     def _uninstrument(self, **kwargs: Any) -> None:
         set_trace_processors([])

--- a/src/atla_insights/frameworks/openai_agents.py
+++ b/src/atla_insights/frameworks/openai_agents.py
@@ -10,6 +10,7 @@ from atla_insights.suppression import NoOpContextManager, is_instrumentation_sup
 
 def instrument_openai_agents(
     llm_provider: LLM_PROVIDER_TYPE = "openai",
+    exclusive_processor: bool = False,
 ) -> ContextManager[None]:
     """Instrument the OpenAI Agents SDK.
 
@@ -28,6 +29,8 @@ def instrument_openai_agents(
 
     :param llm_provider (LLM_PROVIDER_TYPE): The LLM provider(s) to instrument. Defaults
         to "openai".
+    :param exclusive_processor (bool): Whether to use an exclusive processor for the
+        OpenAI Agents SDK. Defaults to False.
     :return (ContextManager[None]): A context manager that instruments OpenAI Agents SDK.
     """
     if is_instrumentation_suppressed():
@@ -38,7 +41,7 @@ def instrument_openai_agents(
     )
 
     # Create an instrumentor for the OpenAI Agents SDK.
-    openai_agents_instrumentor = AtlaOpenAIAgentsInstrumentor()
+    openai_agents_instrumentor = AtlaOpenAIAgentsInstrumentor(exclusive_processor)
 
     # Create an instrumentor for the underlying LLM provider(s).
     llm_provider_instrumentors = get_instrumentors_for_provider(llm_provider)

--- a/uv.lock
+++ b/uv.lock
@@ -240,7 +240,7 @@ wheels = [
 
 [[package]]
 name = "atla-insights"
-version = "0.0.28"
+version = "0.0.29"
 source = { editable = "." }
 dependencies = [
     { name = "cuid2" },


### PR DESCRIPTION
Openinference changes their default behavior to exclusive processing of openai agents sdk traces in [this commit](https://github.com/Arize-ai/openinference/commit/d56abb1935aa4a96925214c39cef045381ab9b15)

We reverse this default & expose it as a flag